### PR TITLE
feat: 실시간 접속자 수 API 및 리펙토링

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ build/
 !**/src/main/**/build/
 !**/src/test/**/build/
 **/.env
+.claude/**
 
 ### STS ###
 .apt_generated

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,244 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+**Study With Someone (SWS)** - A WebSocket-based WebRTC peer matching service built with Spring Boot. The application pairs peers in real-time for video/audio streaming using a publisher-subscriber model with Redis-backed queues and distributed locking for concurrent safety.
+
+## Build & Development Commands
+
+### Building
+```bash
+# Build with tests
+./gradlew build
+
+# Build without tests (used in CI/CD)
+./gradlew build -x test
+
+# Clean build artifacts
+./gradlew clean
+```
+
+### Running Locally
+```bash
+# Run the application (requires .env file with Redis credentials)
+./gradlew bootRun
+
+# Or build and run the JAR
+./gradlew bootJar
+java -jar build/libs/sws-0.0.1-SNAPSHOT.jar
+```
+
+### Testing
+```bash
+# Run all tests
+./gradlew test
+
+# Run specific test class
+./gradlew test --tests "com.koa.sws.service.RedisQueueServiceTest"
+```
+
+### Docker
+```bash
+# Build the application first
+./gradlew build -x test
+
+# Build Docker image
+docker build -t sws:latest .
+
+# Run container with environment file
+docker run -d --env-file .env -p 8080:8080 --name sws sws:latest
+```
+
+## Core Architecture
+
+### Peer Matching Flow
+
+The system uses a **dual-queue publisher-subscriber matching model**:
+
+1. **Connection**: Client connects via WebSocket to `/signal` endpoint
+2. **Registration**: Peer registers as BOTH publisher AND subscriber simultaneously
+3. **Matching**: System attempts to match from opposing queue (publisher ↔ subscriber)
+4. **Queue Wait**: If no match found, peer is added to appropriate queue(s)
+5. **Match Confirmation**: Both peers receive PUBLISH/SUBSCRIBE messages with partner IDs
+6. **WebRTC Signaling**: Peers exchange OFFER/ANSWER/ICE messages via the server relay
+7. **Disconnection & Rematch**: When peer disconnects, partner is automatically rematched
+
+### Service Layer Architecture
+
+**MatchService** (`service/MatchService.java`)
+- Core orchestration service for peer matching
+- Manages dual registration (publisher + subscriber)
+- Validates sessions and prevents invalid matches (self-matching, circular dependencies)
+- Handles rematching when peers disconnect
+- Relays WebRTC signaling messages (OFFER/ANSWER/ICE) between matched peers
+
+**RedisQueueService** (`service/RedisQueueService.java`)
+- Manages two Redis-backed FIFO queues: `sws:publishQueue` and `sws:subscribeQueue`
+- Uses `@DistributedLock` annotation on pop operations for concurrent safety
+- Ensures atomic queue operations across multiple application instances
+
+**SessionService** (`service/SessionService.java`)
+- Maintains two concurrent maps:
+  - `websocketSessions`: Maps peer ID → WebSocketSession
+  - `peerSessions`: Maps peer ID → PeerSession (relationship metadata)
+- Tracks publisher/subscriber relationships
+- Provides session lifecycle management
+
+### Distributed Locking System
+
+**@DistributedLock Annotation** (`aop/DistributedLock.java`)
+- Redisson-based distributed lock for concurrent operations
+- Default parameters: `waitTime=5s`, `leaseTime=3s`
+- Supports Spring EL expressions for dynamic lock keys
+- Example: `@DistributedLock(key = "'publishQueue'")`
+
+**DistributedLockAop** (`aop/DistributedLockAop.java`)
+- AOP aspect that intercepts `@DistributedLock` methods
+- Acquires Redisson RLock before execution
+- Automatically releases lock in finally block (prevents deadlocks)
+- Used on `RedisQueueService.popFrom*Queue()` methods to prevent duplicate peer allocation
+
+**AopForTransaction** (`aop/AopForTransaction.java`)
+- Ensures distributed lock operations execute in new transactions (`REQUIRES_NEW`)
+- Prevents lock/transaction deadlocks
+
+### Message Types
+
+| Type | Direction | Purpose |
+|------|-----------|---------|
+| `PUBLISH` | Server → Peer | "You are now publishing to peer X" |
+| `SUBSCRIBE` | Server → Peer | "You are now subscribing from peer X" |
+| `OFFER` | Peer → Peer | WebRTC SDP offer (relayed) |
+| `ANSWER` | Peer → Peer | WebRTC SDP answer (relayed) |
+| `ICE` | Peer → Peer | ICE candidate (relayed) |
+| `LEAVE` | Server → Peer | Partner disconnected |
+| `ERROR` | Server → Peer | Error notification |
+
+### Critical Matching Logic
+
+**Queue Validation** (`MatchService.getWaitingSubscriber()/getWaitingPublisher()`):
+- Loops through queue candidates until valid match found
+- Skips invalid sessions (closed connections)
+- Prevents self-matching (peer cannot match with itself)
+- Prevents circular dependencies (subscriber cannot become publisher of their own publisher)
+- Restores invalid candidates to queue for re-matching
+
+**Match Execution** (`MatchService.match()`):
+1. Validates both sessions are still open
+2. Sends PUBLISH message to publisher with subscriber's ID
+3. Sends SUBSCRIBE message to subscriber with publisher's ID
+4. Updates PeerSession bidirectional relationships
+
+## Configuration
+
+### Environment Variables (.env)
+```properties
+REDIS_HOST=<redis-host>
+REDIS_PORT=<redis-port>
+REDIS_PASSWORD=<redis-password>
+REDIS_TIMEOUT=60000
+FRONT_URL=<frontend-origin-url>
+```
+
+### CORS Configuration
+WebSocket endpoint `/signal` allows origins from:
+- `http://localhost:3000` (development)
+- `${FRONT_URL}` (production, configured via .env)
+
+## CI/CD Pipeline
+
+**Workflow**: `.github/workflows/deploy_backend.yml`
+
+Triggers on push/PR to `develop` branch:
+
+1. **Build Stage**:
+   - Checkout code
+   - Inject `.env` from GitHub Secrets (`ENV_FILE`)
+   - Setup JDK 17 (Temurin)
+   - Build with Gradle (skip tests)
+   - Build Docker image
+   - Push to Docker Hub
+
+2. **Deploy Stage**:
+   - SSH to production server
+   - Pull latest image
+   - Stop/remove existing container
+   - Start new container with environment variables
+   - Expose port 8080
+
+**Required GitHub Secrets**:
+- `ENV_FILE` - Complete .env file content
+- `DOCKERHUB_USERNAME`, `DOCKERHUB_TOKEN`, `DOCKER_IMAGE_NAME`
+- `SERVER_HOST`, `SERVER_USER`, `SERVER_SSH_KEY`
+
+## Important Implementation Notes
+
+### When Working with Matching Logic
+
+1. **Always validate sessions** before sending messages - use `session.isOpen()` check
+2. **Queue operations must be locked** - use `@DistributedLock` for any new queue operations
+3. **Prevent matching loops** - validate that `peer.publisher != newSubscriber` and vice versa
+4. **Handle disconnections gracefully** - always notify partner peer with LEAVE message before cleanup
+5. **Restore to queue on validation failure** - invalid candidates should be re-queued, not dropped
+
+### When Adding New Services
+
+1. Use `@RequiredArgsConstructor` (Lombok) for dependency injection
+2. Add `@Slf4j` for logging
+3. For Redis operations requiring atomicity, use `@DistributedLock`
+4. Follow existing transaction propagation patterns with `AopForTransaction`
+
+### WebSocket Message Handling
+
+All WebSocket messages are JSON-serialized `SignalMessage` objects. When adding new message types:
+1. Add enum value to `MessageType.java`
+2. Add handler case in `SignalingWebSocketHandler.handleTextMessage()`
+3. Ensure target session exists and is open before sending
+4. Log appropriately with emoji prefixes (⭐ for connection, 🔴 for disconnect)
+
+### Testing Distributed Systems
+
+See `RedisQueueServiceTest.java` for examples of:
+- Testing distributed locks under concurrency (50 threads)
+- Validating atomic queue operations
+- Ensuring no duplicate pops across threads
+
+Run concurrent tests multiple times to catch race conditions:
+```bash
+./gradlew test --tests "RedisQueueServiceTest" --rerun-tasks
+```
+
+## Dependencies
+
+- **Spring Boot 3.5.7** (Web, WebSocket, Data Redis, AOP)
+- **Redisson 3.52.0** - Distributed locks and Redis client
+- **Lombok** - Boilerplate reduction
+- **JUnit 5** - Testing framework
+
+## Project Structure
+
+```
+src/main/java/com/koa/sws/
+├── SwsApplication.java          # Entry point
+├── handler/
+│   └── SignalingWebSocketHandler.java  # WebSocket message handler
+├── config/
+│   ├── WebSocketConfig.java     # WebSocket endpoint configuration
+│   └── RedissonConfig.java      # Redisson client setup
+├── service/
+│   ├── MatchService.java        # Core matching orchestration
+│   ├── RedisQueueService.java   # Queue operations with locks
+│   └── SessionService.java      # Session lifecycle management
+├── aop/
+│   ├── DistributedLock.java     # Lock annotation
+│   ├── DistributedLockAop.java  # Lock aspect
+│   ├── AopForTransaction.java   # Transaction helper
+│   └── CustomSpringELParser.java # Dynamic lock key parser
+└── model/
+    ├── SignalMessage.java       # WebSocket message structure
+    ├── PeerSession.java         # Peer relationship metadata
+    ├── MessageType.java         # Message type enum
+    └── Role.java                # Peer role enum
+```

--- a/src/main/java/com/koa/sws/aop/DistributedLock.java
+++ b/src/main/java/com/koa/sws/aop/DistributedLock.java
@@ -1,5 +1,6 @@
 package com.koa.sws.aop;
 
+import com.koa.sws.constant.DistributedLockConstants;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;

--- a/src/main/java/com/koa/sws/aop/DistributedLockAop.java
+++ b/src/main/java/com/koa/sws/aop/DistributedLockAop.java
@@ -1,5 +1,6 @@
 package com.koa.sws.aop;
 
+import com.koa.sws.constant.DistributedLockConstants;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.ProceedingJoinPoint;
@@ -18,8 +19,6 @@ import java.lang.reflect.Method;
 @RequiredArgsConstructor
 public class DistributedLockAop {
 
-    private static final String REDISSON_LOCK_PREFIX = "LOCK:";
-
     private final RedissonClient redissonClient;
     private final AopForTransaction aopForTranscation;
 
@@ -29,8 +28,8 @@ public class DistributedLockAop {
         Method method = signature.getMethod();
         DistributedLock distributedLock = method.getAnnotation(DistributedLock.class);
 
-        String key = REDISSON_LOCK_PREFIX + CustomSpringELParser.getDynamicValue(signature.getParameterNames(), joinPoint.getArgs(), distributedLock.key());
-        RLock rLock = redissonClient.getLock(key);  // (1)
+        String key = DistributedLockConstants.LOCK_PREFIX + CustomSpringELParser.getDynamicValue(signature.getParameterNames(), joinPoint.getArgs(), distributedLock.key());
+        RLock rLock = redissonClient.getLock(key);
 
         try {
             boolean available = rLock.tryLock(
@@ -39,17 +38,25 @@ public class DistributedLockAop {
                     distributedLock.timeUnit());
 
             if (!available) {
+                log.warn("Failed to acquire lock within wait time - key: {}, waitTime: {} {}",
+                        key, distributedLock.waitTime(), distributedLock.timeUnit());
                 return false;
             }
 
+            log.debug("Lock acquired - key: {}", key);
+
             return aopForTranscation.proceed(joinPoint);
         } catch (InterruptedException e) {
-            throw new InterruptedException();
+            Thread.currentThread().interrupt();
+            log.error("Thread interrupted while waiting for lock - key: {}", key, e);
+            throw e;
         } finally {
             try {
-                rLock.unlock();
+                if (rLock.isHeldByCurrentThread()) {
+                    rLock.unlock();
+                }
             } catch (IllegalMonitorStateException e) {
-                log.info("Redisson Lock Already UnLock");
+                log.warn("Lock was already released or not held by current thread - key: {}", key, e);
             }
         }
     }

--- a/src/main/java/com/koa/sws/config/WebSocketConfig.java
+++ b/src/main/java/com/koa/sws/config/WebSocketConfig.java
@@ -13,14 +13,15 @@ import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry
 @RequiredArgsConstructor
 public class WebSocketConfig implements WebSocketConfigurer {
 
-    @Value("${front.url}")
-    private String frontUrl;
+    @Value("${websocket.allowed-origins}")
+    private String allowedOrigins;
 
     private final SignalingWebSocketHandler signalingWebSocketHandler;
 
     @Override
     public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
+        String[] origins = allowedOrigins.split(",");
         registry.addHandler(signalingWebSocketHandler, "/signal")
-                .setAllowedOrigins("http://localhost:3000", frontUrl);
+                .setAllowedOrigins(origins);
     }
 }

--- a/src/main/java/com/koa/sws/constant/DistributedLockConstants.java
+++ b/src/main/java/com/koa/sws/constant/DistributedLockConstants.java
@@ -1,0 +1,14 @@
+package com.koa.sws.constant;
+
+import java.util.concurrent.TimeUnit;
+
+public final class DistributedLockConstants {
+    private DistributedLockConstants() {
+        throw new UnsupportedOperationException("This is a utility class and cannot be instantiated");
+    }
+
+    public static final long DEFAULT_WAIT_TIME_SECONDS = 5L;
+    public static final long DEFAULT_LEASE_TIME_SECONDS = 3L;
+    public static final TimeUnit DEFAULT_TIME_UNIT = TimeUnit.SECONDS;
+    public static final String LOCK_PREFIX = "LOCK:";
+}

--- a/src/main/java/com/koa/sws/constant/RedisKeyConstants.java
+++ b/src/main/java/com/koa/sws/constant/RedisKeyConstants.java
@@ -1,0 +1,13 @@
+package com.koa.sws.constant;
+
+public final class RedisKeyConstants {
+    private RedisKeyConstants() {
+        throw new UnsupportedOperationException("This is a utility class and cannot be instantiated");
+    }
+
+    private static final String PREFIX = "sws";
+
+    public static final String PUBLISH_QUEUE = PREFIX + ":publishQueue";
+    public static final String SUBSCRIBE_QUEUE = PREFIX + ":subscribeQueue";
+    public static final String LOCK_PREFIX = PREFIX + ":lock:";
+}

--- a/src/main/java/com/koa/sws/controller/ViewerController.java
+++ b/src/main/java/com/koa/sws/controller/ViewerController.java
@@ -1,0 +1,20 @@
+package com.koa.sws.controller;
+
+import com.koa.sws.service.SessionService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@RestController
+@RequiredArgsConstructor
+public class ViewerController {
+
+    private final SessionService sessionService;
+
+    @GetMapping("/viewers")
+    public Map<String, Integer> getViewerCount() {
+        return Map.of("count", sessionService.getSessionCount());
+    }
+}

--- a/src/main/java/com/koa/sws/exception/InvalidMessageException.java
+++ b/src/main/java/com/koa/sws/exception/InvalidMessageException.java
@@ -1,0 +1,11 @@
+package com.koa.sws.exception;
+
+public class InvalidMessageException extends SignalingException {
+    public InvalidMessageException(String message) {
+        super(message);
+    }
+
+    public InvalidMessageException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/koa/sws/exception/SessionException.java
+++ b/src/main/java/com/koa/sws/exception/SessionException.java
@@ -1,0 +1,11 @@
+package com.koa.sws.exception;
+
+public class SessionException extends SignalingException {
+    public SessionException(String message) {
+        super(message);
+    }
+
+    public SessionException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/koa/sws/exception/SignalingException.java
+++ b/src/main/java/com/koa/sws/exception/SignalingException.java
@@ -1,0 +1,11 @@
+package com.koa.sws.exception;
+
+public class SignalingException extends RuntimeException {
+    public SignalingException(String message) {
+        super(message);
+    }
+
+    public SignalingException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/koa/sws/handler/SignalingWebSocketHandler.java
+++ b/src/main/java/com/koa/sws/handler/SignalingWebSocketHandler.java
@@ -1,6 +1,9 @@
 package com.koa.sws.handler;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.koa.sws.exception.InvalidMessageException;
+import com.koa.sws.exception.SessionException;
 import com.koa.sws.model.MessageType;
 import com.koa.sws.model.SignalMessage;
 import com.koa.sws.service.MatchService;
@@ -25,7 +28,7 @@ public class SignalingWebSocketHandler extends TextWebSocketHandler {
     @Override
     public void afterConnectionEstablished(WebSocketSession session) {
         String peerId = sessionService.register(session);
-        log.info("⭐ CONNECTED: peerId={}", peerId);
+        log.info("WebSocket connection established - peerId: {}, sessionId: {}", peerId, session.getId());
 
         matchService.registerPeer(session);
     }
@@ -33,42 +36,74 @@ public class SignalingWebSocketHandler extends TextWebSocketHandler {
     @Override
     protected void handleTextMessage(WebSocketSession session, TextMessage message) throws Exception {
         try {
-            SignalMessage signalMessage = objectMapper.readValue(message.getPayload(), SignalMessage.class);
-
-            if (!session.isOpen()) {
-                log.warn("Received message from unopen session: {}", session.getId());
-                return;
-            }
-
+            validateSession(session);
+            SignalMessage signalMessage = parseAndValidateMessage(message);
             signalMessage.setMyId(session.getId());
-
-            switch (signalMessage.getType()) {
-                case OFFER:
-                case ANSWER:
-                case ICE:
-                    matchService.relaySignalMessage(signalMessage);
-                    break;
-                case LEAVE:
-                    //matchService.unregisterPeer(session.getId());
-                    break;
-                case JOIN:
-                    break;
-                default:
-                    log.warn("Unknown message type: {}", signalMessage.getType());
-                    matchService.sendMessage(session, new SignalMessage(MessageType.ERROR, session.getId(), null, "Unknown message type"));
-            }
+            processMessage(session, signalMessage);
+        } catch (InvalidMessageException e) {
+            log.warn("Invalid message received - sessionId: {}, error: {}", session.getId(), e.getMessage());
+            sendErrorResponse(session, "Invalid message format");
+        } catch (SessionException e) {
+            log.warn("Session error - sessionId: {}, error: {}", session.getId(), e.getMessage());
         } catch (Exception e) {
-            log.error("Error handling message", e);
+            log.error("Unexpected error handling message - sessionId: {}", session.getId(), e);
+            sendErrorResponse(session, "Internal server error");
+        }
+    }
 
-            if (session.isOpen())
-                matchService.sendMessage(session, new SignalMessage(MessageType.ERROR, session.getId(), null, "Failed message"));
+    private void validateSession(WebSocketSession session) throws SessionException {
+        if (session == null) {
+            throw new SessionException("Session is null");
+        }
+        if (!session.isOpen()) {
+            throw new SessionException("Session is closed: " + session.getId());
+        }
+    }
+
+    private SignalMessage parseAndValidateMessage(TextMessage message) throws InvalidMessageException {
+        if (message == null || message.getPayload() == null || message.getPayload().trim().isEmpty()) {
+            throw new InvalidMessageException("Message payload cannot be null or empty");
         }
 
+        try {
+            SignalMessage signalMessage = objectMapper.readValue(message.getPayload(), SignalMessage.class);
+
+            if (signalMessage == null || signalMessage.getType() == null) {
+                throw new InvalidMessageException("Message type is required");
+            }
+
+            return signalMessage;
+        } catch (JsonProcessingException e) {
+            throw new InvalidMessageException("Failed to parse message JSON", e);
+        }
+    }
+
+    private void processMessage(WebSocketSession session, SignalMessage signalMessage) {
+        switch (signalMessage.getType()) {
+            case OFFER:
+            case ANSWER:
+            case ICE:
+                matchService.relaySignalMessage(signalMessage);
+                break;
+            case JOIN:
+                log.debug("JOIN message received - sessionId: {}", session.getId());
+                break;
+            default:
+                log.warn("Unknown message type - sessionId: {}, type: {}", session.getId(), signalMessage.getType());
+                sendErrorResponse(session, "Unknown message type");
+        }
+    }
+
+    private void sendErrorResponse(WebSocketSession session, String errorMessage) {
+        if (session != null && session.isOpen()) {
+            matchService.sendMessage(session, new SignalMessage(MessageType.ERROR, session.getId(), null, errorMessage));
+        }
     }
 
     @Override
     public void afterConnectionClosed(WebSocketSession session, CloseStatus status) {
         matchService.unregisterPeer(session.getId());
-        log.info("🔴 DISCONNECTED: peerId={} status={}", session.getId(), status);
+        log.info("WebSocket connection closed - peerId: {}, status: {}, reason: {}",
+                session.getId(), status.getCode(), status.getReason());
     }
 }

--- a/src/main/java/com/koa/sws/handler/SignalingWebSocketHandler.java
+++ b/src/main/java/com/koa/sws/handler/SignalingWebSocketHandler.java
@@ -44,6 +44,7 @@ public class SignalingWebSocketHandler extends TextWebSocketHandler {
             log.warn("Invalid message received - sessionId: {}, error: {}", session.getId(), e.getMessage());
             sendErrorResponse(session, "Invalid message format");
         } catch (SessionException e) {
+            // 세션이 null이거나 닫힌 상태이므로 에러 응답 전송 불가
             log.warn("Session error - sessionId: {}, error: {}", session.getId(), e.getMessage());
         } catch (Exception e) {
             log.error("Unexpected error handling message - sessionId: {}", session.getId(), e);

--- a/src/main/java/com/koa/sws/handler/SignalingWebSocketHandler.java
+++ b/src/main/java/com/koa/sws/handler/SignalingWebSocketHandler.java
@@ -8,6 +8,7 @@ import com.koa.sws.model.MessageType;
 import com.koa.sws.model.SignalMessage;
 import com.koa.sws.service.MatchService;
 import com.koa.sws.service.SessionService;
+import com.koa.sws.service.SignalMessageRelayService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -24,6 +25,7 @@ public class SignalingWebSocketHandler extends TextWebSocketHandler {
     private final ObjectMapper objectMapper;
     private final SessionService sessionService;
     private final MatchService matchService;
+    private final SignalMessageRelayService relayService;
 
     @Override
     public void afterConnectionEstablished(WebSocketSession session) {
@@ -84,7 +86,7 @@ public class SignalingWebSocketHandler extends TextWebSocketHandler {
             case OFFER:
             case ANSWER:
             case ICE:
-                matchService.relaySignalMessage(signalMessage);
+                relayService.relaySignalMessage(signalMessage);
                 break;
             case JOIN:
                 log.debug("JOIN message received - sessionId: {}", session.getId());
@@ -97,7 +99,7 @@ public class SignalingWebSocketHandler extends TextWebSocketHandler {
 
     private void sendErrorResponse(WebSocketSession session, String errorMessage) {
         if (session != null && session.isOpen()) {
-            matchService.sendMessage(session, new SignalMessage(MessageType.ERROR, session.getId(), null, errorMessage));
+            relayService.sendMessage(session, new SignalMessage(MessageType.ERROR, session.getId(), null, errorMessage));
         }
     }
 

--- a/src/main/java/com/koa/sws/model/PeerRelation.java
+++ b/src/main/java/com/koa/sws/model/PeerRelation.java
@@ -5,12 +5,12 @@ import lombok.Setter;
 
 @Getter
 @Setter
-public class PeerSession {
+public class PeerRelation {
     private final String peerId;
     private String subscriber;
     private String publisher;
 
-    public PeerSession(String peerId) {
+    public PeerRelation(String peerId) {
         this.peerId = peerId;
     }
 }

--- a/src/main/java/com/koa/sws/model/PeerSession.java
+++ b/src/main/java/com/koa/sws/model/PeerSession.java
@@ -1,30 +1,16 @@
 package com.koa.sws.model;
 
-import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
 
-@Data
+@Getter
+@Setter
 public class PeerSession {
-    private String peerId;
-    private String subscribeFrom;
-    private String publishTo;
+    private final String peerId;
+    private String subscriber;
+    private String publisher;
 
     public PeerSession(String peerId) {
         this.peerId = peerId;
-    }
-
-    public void setSubscriber(String subscriberId) {
-        this.subscribeFrom = subscriberId;
-    }
-
-    public void setPublisher(String publisherId) {
-        this.publishTo = publisherId;
-    }
-
-    public String getSubscriber() {
-        return this.subscribeFrom;
-    }
-
-    public String getPublisher() {
-        return this.publishTo;
     }
 }

--- a/src/main/java/com/koa/sws/model/QueueType.java
+++ b/src/main/java/com/koa/sws/model/QueueType.java
@@ -1,0 +1,53 @@
+package com.koa.sws.model;
+
+import com.koa.sws.service.RedisQueueService;
+
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+public enum QueueType {
+    PUBLISHER(
+            RedisQueueService::popFromPublishQueue,
+            RedisQueueService::addToPublishQueue,
+            RedisQueueService::getPublishQueueSize,
+            PeerSession::getSubscriber
+    ),
+    SUBSCRIBER(
+            RedisQueueService::popFromSubscribeQueue,
+            RedisQueueService::addToSubscribeQueue,
+            RedisQueueService::getSubscribeQueueSize,
+            PeerSession::getPublisher
+    );
+
+    private final Function<RedisQueueService, String> popFunction;
+    private final java.util.function.BiConsumer<RedisQueueService, String> addFunction;
+    private final Function<RedisQueueService, Long> sizeFunction;
+    private final Function<PeerSession, String> peerGetter;
+
+    QueueType(Function<RedisQueueService, String> popFunction,
+              java.util.function.BiConsumer<RedisQueueService, String> addFunction,
+              Function<RedisQueueService, Long> sizeFunction,
+              Function<PeerSession, String> peerGetter) {
+        this.popFunction = popFunction;
+        this.addFunction = addFunction;
+        this.sizeFunction = sizeFunction;
+        this.peerGetter = peerGetter;
+    }
+
+    public String pop(RedisQueueService queueService) {
+        return popFunction.apply(queueService);
+    }
+
+    public void add(RedisQueueService queueService, String peerId) {
+        addFunction.accept(queueService, peerId);
+    }
+
+    public Long getSize(RedisQueueService queueService) {
+        return sizeFunction.apply(queueService);
+    }
+
+    public String getConnectedPeer(PeerSession peerSession) {
+        return peerGetter.apply(peerSession);
+    }
+}

--- a/src/main/java/com/koa/sws/model/Role.java
+++ b/src/main/java/com/koa/sws/model/Role.java
@@ -1,6 +1,0 @@
-package com.koa.sws.model;
-
-public enum Role {
-    PUBLISHER,
-    SUBSCRIBER
-}

--- a/src/main/java/com/koa/sws/service/FindPeerService.java
+++ b/src/main/java/com/koa/sws/service/FindPeerService.java
@@ -6,6 +6,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.web.socket.WebSocketSession;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * 대기열에서 매칭 가능한 피어를 탐색하는 서비스
  */
@@ -36,10 +39,11 @@ public class FindPeerService {
     private WebSocketSession findWaitingPeer(WebSocketSession session, QueueType queueType) {
         PeerSession myPeerSession = sessionService.getPeerSession(session.getId());
         String myId = session.getId();
+        String myConnectedPeer = myPeerSession != null ? queueType.getConnectedPeer(myPeerSession) : null;
 
         String candidateId = null;
         WebSocketSession candidateSession = null;
-        String peerToRestore = null;
+        List<String> peersToRestore = new ArrayList<>();
         boolean needRestoreMine = false;
 
         long maxRetries = queueType.getSize(queueService);
@@ -51,11 +55,10 @@ public class FindPeerService {
             attempts++;
 
             // Validation 1: Cannot be connected to my existing peer (prevent circular dependency)
-            String myConnectedPeer = queueType.getConnectedPeer(myPeerSession);
             if (myConnectedPeer != null && !isPeerAvailable(candidateId, myConnectedPeer)) {
                 log.warn("Peer not available due to circular dependency - candidate: {}, myConnectedPeer: {}",
                         candidateId, myConnectedPeer);
-                peerToRestore = candidateId;
+                peersToRestore.add(candidateId);
                 candidateId = null;
                 candidateSession = null;
                 continue;
@@ -79,8 +82,8 @@ public class FindPeerService {
         }
 
         // Restore peers back to queue if needed
-        if (peerToRestore != null) {
-            queueType.add(queueService, peerToRestore);
+        for (String peer : peersToRestore) {
+            queueType.add(queueService, peer);
         }
         if (needRestoreMine) {
             queueType.add(queueService, myId);

--- a/src/main/java/com/koa/sws/service/FindPeerService.java
+++ b/src/main/java/com/koa/sws/service/FindPeerService.java
@@ -1,6 +1,6 @@
 package com.koa.sws.service;
 
-import com.koa.sws.model.PeerSession;
+import com.koa.sws.model.PeerRelation;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -37,9 +37,9 @@ public class FindPeerService {
      * @return 매칭 가능한 피어의 세션, 없으면 null
      */
     private WebSocketSession findWaitingPeer(WebSocketSession session, QueueType queueType) {
-        PeerSession myPeerSession = sessionService.getPeerSession(session.getId());
+        PeerRelation myPeerRelation = sessionService.getPeerRelation(session.getId());
         String myId = session.getId();
-        String myConnectedPeer = myPeerSession != null ? queueType.getConnectedPeer(myPeerSession) : null;
+        String myConnectedPeer = myPeerRelation != null ? queueType.getConnectedPeer(myPeerRelation) : null;
 
         String candidateId = null;
         WebSocketSession candidateSession = null;

--- a/src/main/java/com/koa/sws/service/FindPeerService.java
+++ b/src/main/java/com/koa/sws/service/FindPeerService.java
@@ -1,0 +1,100 @@
+package com.koa.sws.service;
+
+import com.koa.sws.model.PeerSession;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.socket.WebSocketSession;
+
+/**
+ * 대기열에서 매칭 가능한 피어를 탐색하는 서비스
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class FindPeerService {
+
+    private final SessionService sessionService;
+    private final RedisQueueService queueService;
+
+    public String findWaitingSubscriber(WebSocketSession session) {
+        WebSocketSession subscriberSession = findWaitingPeer(session, QueueType.SUBSCRIBER);
+        return subscriberSession != null ? subscriberSession.getId() : null;
+    }
+
+    public String findWaitingPublisher(WebSocketSession session) {
+        WebSocketSession publisherSession = findWaitingPeer(session, QueueType.PUBLISHER);
+        return publisherSession != null ? publisherSession.getId() : null;
+    }
+
+    /**
+     * 대기열에서 유효한 매칭 후보를 탐색
+     * @param session 현재 세션
+     * @param queueType 찾을 피어의 큐 타입 (PUBLISHER 또는 SUBSCRIBER)
+     * @return 매칭 가능한 피어의 세션, 없으면 null
+     */
+    private WebSocketSession findWaitingPeer(WebSocketSession session, QueueType queueType) {
+        PeerSession myPeerSession = sessionService.getPeerSession(session.getId());
+        String myId = session.getId();
+
+        String candidateId = null;
+        WebSocketSession candidateSession = null;
+        String peerToRestore = null;
+        boolean needRestoreMine = false;
+
+        long maxRetries = queueType.getSize(queueService);
+        long attempts = 0;
+
+        while (queueType.getSize(queueService) > 0 && !sessionService.isSessionValid(candidateSession) && attempts < maxRetries) {
+            candidateId = queueType.pop(queueService);
+            candidateSession = sessionService.getSession(candidateId);
+            attempts++;
+
+            // Validation 1: Cannot be connected to my existing peer (prevent circular dependency)
+            String myConnectedPeer = queueType.getConnectedPeer(myPeerSession);
+            if (myConnectedPeer != null && !isPeerAvailable(candidateId, myConnectedPeer)) {
+                log.warn("Peer not available due to circular dependency - candidate: {}, myConnectedPeer: {}",
+                        candidateId, myConnectedPeer);
+                peerToRestore = candidateId;
+                candidateId = null;
+                candidateSession = null;
+                continue;
+            }
+
+            // Validation 2: Cannot be myself (prevent self-matching)
+            if (candidateId != null && candidateId.equals(myId)) {
+                log.debug("Skipping self-match - peerId: {}", candidateId);
+                needRestoreMine = true;
+                candidateId = null;
+                candidateSession = null;
+                continue;
+            }
+
+            // If session is invalid, continue to next candidate
+            if (!sessionService.isSessionValid(candidateSession)) {
+                log.debug("Invalid session found in queue - peerId: {}", candidateId);
+                candidateId = null;
+                candidateSession = null;
+            }
+        }
+
+        // Restore peers back to queue if needed
+        if (peerToRestore != null) {
+            queueType.add(queueService, peerToRestore);
+        }
+        if (needRestoreMine) {
+            queueType.add(queueService, myId);
+        }
+
+        if (candidateId == null || candidateSession == null) {
+            log.debug("No waiting peer in {} queue", queueType);
+            return null;
+        }
+
+        return candidateSession;
+    }
+
+    private boolean isPeerAvailable(String targetPeerId, String myPeerId) {
+        return targetPeerId != null && myPeerId != null && !targetPeerId.equals(myPeerId);
+    }
+}

--- a/src/main/java/com/koa/sws/service/MatchService.java
+++ b/src/main/java/com/koa/sws/service/MatchService.java
@@ -1,7 +1,7 @@
 package com.koa.sws.service;
 
 import com.koa.sws.model.MessageType;
-import com.koa.sws.model.PeerSession;
+import com.koa.sws.model.PeerRelation;
 import com.koa.sws.model.SignalMessage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -56,15 +56,15 @@ public class MatchService {
      */
     public void unregisterPeer(String peerId) {
         // 1. Remove peer session, websocket session
-        PeerSession peerSession = sessionService.remove(peerId);
-        if (peerSession == null) {
+        PeerRelation peerRelation = sessionService.remove(peerId);
+        if (peerRelation == null) {
             log.warn("not found user: {}", peerId);
             return;
         }
 
         // 2. Notice to publisher, subscriber and Rematch
-        unregisterMyPublisher(peerSession.getPublisher(), peerId);
-        unregisterMySubscriber(peerSession.getSubscriber(), peerId);
+        unregisterMyPublisher(peerRelation.getPublisher(), peerId);
+        unregisterMySubscriber(peerRelation.getSubscriber(), peerId);
     }
     
     private void unregisterMyPublisher(String publisherId, String myId) {
@@ -74,8 +74,8 @@ public class MatchService {
         }
 
         WebSocketSession publisherSession = sessionService.getSession(publisherId);
-        PeerSession publisherPeerSession = sessionService.getPeerSession(publisherId);
-        if (!sessionService.isSessionValid(publisherSession) || publisherPeerSession == null) {
+        PeerRelation publisherPeerRelation = sessionService.getPeerRelation(publisherId);
+        if (!sessionService.isSessionValid(publisherSession) || publisherPeerRelation == null) {
             log.warn("Publisher session not found: {}", publisherId);
             return;
         }
@@ -98,9 +98,9 @@ public class MatchService {
         }
 
         WebSocketSession subscriberSession = sessionService.getSession(subscriberId);
-        PeerSession subscriberPeerSession = sessionService.getPeerSession(subscriberId);
+        PeerRelation subscriberPeerRelation = sessionService.getPeerRelation(subscriberId);
 
-        if (!sessionService.isSessionValid(subscriberSession) || subscriberPeerSession == null) {
+        if (!sessionService.isSessionValid(subscriberSession) || subscriberPeerRelation == null) {
             log.warn("Subscriber session not found: {}", subscriberId);
             return;
         }

--- a/src/main/java/com/koa/sws/service/MatchService.java
+++ b/src/main/java/com/koa/sws/service/MatchService.java
@@ -16,6 +16,7 @@ public class MatchService {
     private final SessionService sessionService;
     private final RedisQueueService queueService;
     private final SignalMessageRelayService relayService;
+    private final FindPeerService queueMatchingService;
 
     /**
      * 사용자 등록
@@ -29,10 +30,9 @@ public class MatchService {
     }
 
     public void registerAsPublisher(WebSocketSession session) {
-
         String myId = session.getId();
 
-        String subscriberId = getWaitingSubscriber(session);
+        String subscriberId = queueMatchingService.findWaitingSubscriber(session);
         if (subscriberId == null) {
             queueService.addToPublishQueue(myId);
         } else {
@@ -41,10 +41,9 @@ public class MatchService {
     }
 
     public void registerAsSubscriber(WebSocketSession session) {
-
         String myId = session.getId();
 
-        String publisherId = getWaitingPublisher(session);
+        String publisherId = queueMatchingService.findWaitingPublisher(session);
         if (publisherId == null) {
             queueService.addToSubscribeQueue(myId);
         } else {
@@ -56,7 +55,6 @@ public class MatchService {
      * 사용자 해제
      */
     public void unregisterPeer(String peerId) {
-
         // 1. Remove peer session, websocket session
         PeerSession peerSession = sessionService.remove(peerId);
         if (peerSession == null) {
@@ -67,27 +65,8 @@ public class MatchService {
         // 2. Notice to publisher, subscriber and Rematch
         unregisterMyPublisher(peerSession.getPublishTo(), peerId);
         unregisterMySubscriber(peerSession.getSubscribeFrom(), peerId);
-
-        // 3. Remove mine in queue -> X (when pop, check the session avaible)
     }
-
-    /**
-     * 메시지 중계 (OFFER, ANSWER, ICE)
-     * Delegates to SignalMessageRelayService
-     */
-    public void relaySignalMessage(SignalMessage message) {
-        relayService.relaySignalMessage(message);
-    }
-
-    /**
-     * WebSocket 메시지 전송
-     * Delegates to SignalMessageRelayService
-     */
-    public void sendMessage(WebSocketSession session, SignalMessage message) {
-        relayService.sendMessage(session, message);
-    }
-
-    //
+    
     private void unregisterMyPublisher(String publisherId, String myId) {
         if (publisherId == null) {
             log.debug("No connected publisher for {}", myId);
@@ -101,10 +80,10 @@ public class MatchService {
             return;
         }
 
-        sendMessage(publisherSession, new SignalMessage(MessageType.LEAVE, publisherId, myId, "Subscriber has left session"));
+        relayService.sendMessage(publisherSession, new SignalMessage(MessageType.LEAVE, publisherId, myId, "Subscriber has left session"));
         sessionService.updateSubscriber(publisherId, null);
 
-        String subscriberId = getWaitingSubscriber(publisherSession);
+        String subscriberId = queueMatchingService.findWaitingSubscriber(publisherSession);
         if (subscriberId != null) {
             match(publisherId, subscriberId);
         } else {
@@ -126,10 +105,10 @@ public class MatchService {
             return;
         }
 
-        sendMessage(subscriberSession, new SignalMessage(MessageType.LEAVE, subscriberId, myId, "Subscriber has left session"));
+        relayService.sendMessage(subscriberSession, new SignalMessage(MessageType.LEAVE, subscriberId, myId, "Subscriber has left session"));
         sessionService.updatePublisher(subscriberId, null);
 
-        String publisherId = getWaitingPublisher(subscriberSession);
+        String publisherId = queueMatchingService.findWaitingPublisher(subscriberSession);
         if (publisherId != null) {
             match(publisherId, subscriberId);
         } else {
@@ -138,85 +117,7 @@ public class MatchService {
         }
     }
 
-    private String getWaitingSubscriber(WebSocketSession session) {
-        WebSocketSession subscriberSession = getWaitingPeer(session, QueueType.SUBSCRIBER);
-        return subscriberSession != null ? subscriberSession.getId() : null;
-    }
-
-    private String getWaitingPublisher(WebSocketSession session) {
-        WebSocketSession publisherSession = getWaitingPeer(session, QueueType.PUBLISHER);
-        return publisherSession != null ? publisherSession.getId() : null;
-    }
-
-    /**
-     * 공통 큐 처리 로직
-     * @param session 현재 세션
-     * @param queueType 찾을 피어의 큐 타입 (PUBLISHER 또는 SUBSCRIBER)
-     * @return 매칭 가능한 피어의 세션, 없으면 null
-     */
-    private WebSocketSession getWaitingPeer(WebSocketSession session, QueueType queueType) {
-        PeerSession myPeerSession = sessionService.getPeerSession(session.getId());
-        String myId = session.getId();
-
-        String candidateId = null;
-        WebSocketSession candidateSession = null;
-        String peerToRestore = null;
-        boolean needRestoreMine = false;
-
-        long maxRetries = queueType.getSize(queueService);
-        long attempts = 0;
-
-        while (queueType.getSize(queueService) > 0 && !sessionService.isSessionValid(candidateSession) && attempts < maxRetries) {
-            candidateId = queueType.pop(queueService);
-            candidateSession = sessionService.getSession(candidateId);
-            attempts++;
-
-            // Validation 1: Cannot be connected to my existing peer (prevent circular dependency)
-            String myConnectedPeer = queueType.getConnectedPeer(myPeerSession);
-            if (myConnectedPeer != null && !isPeerAvailable(candidateId, myConnectedPeer)) {
-                log.warn("Peer not available due to circular dependency - candidate: {}, myConnectedPeer: {}",
-                        candidateId, myConnectedPeer);
-                peerToRestore = candidateId;
-                candidateId = null;
-                candidateSession = null;
-                continue;
-            }
-
-            // Validation 2: Cannot be myself (prevent self-matching)
-            if (candidateId != null && candidateId.equals(myId)) {
-                log.debug("Skipping self-match - peerId: {}", candidateId);
-                needRestoreMine = true;
-                candidateId = null;
-                candidateSession = null;
-                continue;
-            }
-
-            // If session is invalid, continue to next candidate
-            if (!sessionService.isSessionValid(candidateSession)) {
-                log.debug("Invalid session found in queue - peerId: {}", candidateId);
-                candidateId = null;
-                candidateSession = null;
-            }
-        }
-
-        // Restore peers back to queue if needed
-        if (peerToRestore != null) {
-            queueType.add(queueService, peerToRestore);
-        }
-        if (needRestoreMine) {
-            queueType.add(queueService, myId);
-        }
-
-        if (candidateId == null || candidateSession == null) {
-            log.debug("No waiting peer in {} queue", queueType);
-            return null;
-        }
-
-        return candidateSession;
-    }
-
     private void match(String publisherId, String subscriberId) {
-
         // 1. find Session
         WebSocketSession publisherSession = sessionService.getSession(publisherId);
         WebSocketSession subscriberSession = sessionService.getSession(subscriberId);
@@ -226,17 +127,12 @@ public class MatchService {
         }
 
         // 2. send Websocket Message
-        sendMessage(publisherSession, new SignalMessage(MessageType.PUBLISH, publisherId, subscriberId));
-        sendMessage(subscriberSession, new SignalMessage(MessageType.SUBSCRIBE, subscriberId, publisherId));
+        relayService.sendMessage(publisherSession, new SignalMessage(MessageType.PUBLISH, publisherId, subscriberId));
+        relayService.sendMessage(subscriberSession, new SignalMessage(MessageType.SUBSCRIBE, subscriberId, publisherId));
 
         // 3. session info update
         sessionService.updateSubscriber(publisherId, subscriberId);
         sessionService.updatePublisher(subscriberId, publisherId);
         log.info("Peers matched - publisher: {}, subscriber: {}", publisherId, subscriberId);
     }
-
-    private boolean isPeerAvailable(String targetPeerId, String myPeerId) {
-        return targetPeerId != null && myPeerId != null && !targetPeerId.equals(myPeerId);
-    }
-
 }

--- a/src/main/java/com/koa/sws/service/MatchService.java
+++ b/src/main/java/com/koa/sws/service/MatchService.java
@@ -24,13 +24,8 @@ public class MatchService {
      * 2. as subscriber
      */
     public void registerPeer(WebSocketSession session) {
-
-        // 1. register as publisher
-        log.info("🔗 Register as Publisher");
+        log.info("Registering peer as publisher and subscriber - peerId: {}", session.getId());
         registerAsPublisher(session);
-
-        // 2. register as subscriber
-        log.info("🔗 Register as Subscriber");
         registerAsSubscriber(session);
     }
 
@@ -214,7 +209,7 @@ public class MatchService {
         }
 
         if (candidateId == null || candidateSession == null) {
-            log.info("❌ No waiting peer in {} queue", queueType);
+            log.debug("No waiting peer in {} queue", queueType);
             return null;
         }
 
@@ -238,7 +233,7 @@ public class MatchService {
         // 3. session info update
         sessionService.updateSubscriber(publisherId, subscriberId);
         sessionService.updatePublisher(subscriberId, publisherId);
-        log.info("📤 Sent MATCH message) publisher: {}, subscriber: {}", publisherId, subscriberId);
+        log.info("Peers matched - publisher: {}, subscriber: {}", publisherId, subscriberId);
     }
 
     private boolean isPeerAvailable(String targetPeerId, String myPeerId) {

--- a/src/main/java/com/koa/sws/service/MatchService.java
+++ b/src/main/java/com/koa/sws/service/MatchService.java
@@ -63,8 +63,8 @@ public class MatchService {
         }
 
         // 2. Notice to publisher, subscriber and Rematch
-        unregisterMyPublisher(peerSession.getPublishTo(), peerId);
-        unregisterMySubscriber(peerSession.getSubscribeFrom(), peerId);
+        unregisterMyPublisher(peerSession.getPublisher(), peerId);
+        unregisterMySubscriber(peerSession.getSubscriber(), peerId);
     }
     
     private void unregisterMyPublisher(String publisherId, String myId) {
@@ -105,7 +105,7 @@ public class MatchService {
             return;
         }
 
-        relayService.sendMessage(subscriberSession, new SignalMessage(MessageType.LEAVE, subscriberId, myId, "Subscriber has left session"));
+        relayService.sendMessage(subscriberSession, new SignalMessage(MessageType.LEAVE, subscriberId, myId, "Publisher has left session"));
         sessionService.updatePublisher(subscriberId, null);
 
         String publisherId = queueMatchingService.findWaitingPublisher(subscriberSession);
@@ -113,7 +113,7 @@ public class MatchService {
             match(publisherId, subscriberId);
         } else {
             queueService.addToSubscribeQueue(subscriberId);
-            log.info("-> after disconnected add subscriber queue: {}", myId);
+            log.info("-> after disconnected add subscriber queue: {}", subscriberId);
         }
     }
 

--- a/src/main/java/com/koa/sws/service/MatchService.java
+++ b/src/main/java/com/koa/sws/service/MatchService.java
@@ -164,8 +164,8 @@ public class MatchService {
         String peerToRestore = null;
         boolean needRestoreMine = false;
 
-        int maxRetries = 10;
-        int attempts = 0;
+        long maxRetries = queueType.getSize(queueService);
+        long attempts = 0;
 
         while (queueType.getSize(queueService) > 0 && !isSessionValid(candidateSession) && attempts < maxRetries) {
             candidateId = queueType.pop(queueService);

--- a/src/main/java/com/koa/sws/service/MatchService.java
+++ b/src/main/java/com/koa/sws/service/MatchService.java
@@ -3,6 +3,7 @@ package com.koa.sws.service;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.koa.sws.model.MessageType;
 import com.koa.sws.model.PeerSession;
+import com.koa.sws.model.QueueType;
 import com.koa.sws.model.SignalMessage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -41,11 +42,11 @@ public class MatchService {
 
         String myId = session.getId();
 
-        WebSocketSession subscriberSession = getWaitingSubscriber(session);
-        if (subscriberSession == null) {
+        String subscriberId = getWaitingSubscriber(session);
+        if (subscriberId == null) {
             queueService.addToPublishQueue(myId);
         } else {
-            match(myId, subscriberSession.getId());
+            match(myId, subscriberId);
         }
     }
 
@@ -121,9 +122,9 @@ public class MatchService {
         sendMessage(publisherSession, new SignalMessage(MessageType.LEAVE, publisherId, myId, "Subscriber has left session"));
         sessionService.updateSubscriber(publisherId, null);
 
-        WebSocketSession subscriberSession = getWaitingSubscriber(publisherSession);
-        if (subscriberSession != null) {
-            match(publisherId, subscriberSession.getId());
+        String subscriberId = getWaitingSubscriber(publisherSession);
+        if (subscriberId != null) {
+            match(publisherId, subscriberId);
         } else {
             queueService.addToPublishQueue(publisherId);
         }
@@ -155,82 +156,81 @@ public class MatchService {
         }
     }
 
-    private WebSocketSession getWaitingSubscriber(WebSocketSession session) {
-
-        // 1. get my peer session
-        PeerSession peerSession = sessionService.getPeerSession(session.getId());
-
-        String subscriberId = null;
-        WebSocketSession subscriberSession = null;
-
-        boolean needRestoreSubscriber = false;
-        boolean needResotoreMine = false;
-
-        // 2. check subscribe Queue
-        while (queueService.getSubscribeQueueSize() > 0 && !isSessionValid(subscriberSession)) {
-            subscriberId = queueService.popFromSubscribeQueue();
-            subscriberSession = sessionService.getSession(subscriberId);
-
-            // condition1) subscriber cannot be my subsciber as publisher.
-            if (peerSession.getPublisher() != null && !isPeerAvailable(subscriberId, peerSession.getPublisher())) {
-                log.warn("peer is not availble : {} <-> {}" , subscriberId, peerSession.getPublisher());
-                subscriberId = null;
-                needRestoreSubscriber = true;
-            }
-
-            // condition2) subscriber cannot be myself.
-            if (subscriberId != null && subscriberId.equals(session.getId())) {
-                subscriberId = null;
-                needResotoreMine = true;
-            }
-
-        }
-
-        if (needRestoreSubscriber) queueService.addToSubscribeQueue(peerSession.getPublishTo());
-        if (needResotoreMine) queueService.addToSubscribeQueue(session.getId());
-
-        if (subscriberId == null || subscriberSession == null) {
-            log.info("❌ No waiting subscriber in subscribe queue");
-            return null;
-        }
-        return subscriberSession;
+    private String getWaitingSubscriber(WebSocketSession session) {
+        WebSocketSession subscriberSession = getWaitingPeer(session, QueueType.SUBSCRIBER);
+        return subscriberSession != null ? subscriberSession.getId() : null;
     }
 
     private String getWaitingPublisher(WebSocketSession session) {
+        WebSocketSession publisherSession = getWaitingPeer(session, QueueType.PUBLISHER);
+        return publisherSession != null ? publisherSession.getId() : null;
+    }
 
-        PeerSession peerSession = sessionService.getPeerSession(session.getId());
+    /**
+     * 공통 큐 처리 로직
+     * @param session 현재 세션
+     * @param queueType 찾을 피어의 큐 타입 (PUBLISHER 또는 SUBSCRIBER)
+     * @return 매칭 가능한 피어의 세션, 없으면 null
+     */
+    private WebSocketSession getWaitingPeer(WebSocketSession session, QueueType queueType) {
+        PeerSession myPeerSession = sessionService.getPeerSession(session.getId());
+        String myId = session.getId();
 
-        String publisherId = null;
-        WebSocketSession publisherSession = null;
-
-        boolean needRestorePublisher = false;
+        String candidateId = null;
+        WebSocketSession candidateSession = null;
+        String peerToRestore = null;
         boolean needRestoreMine = false;
 
-        while (queueService.getPublishQueueSize() > 0 && !isSessionValid(publisherSession)) {
-            publisherId = queueService.popFromPublishQueue();
-            publisherSession = sessionService.getSession(publisherId);
+        int maxRetries = 10;
+        int attempts = 0;
 
-            if (peerSession.getSubscriber() != null && !isPeerAvailable(publisherId, peerSession.getSubscriber())) {
-                log.warn("peer is not availble : {} <-> {}" , publisherId, peerSession.getSubscriber());
-                publisherId = null;
-                needRestorePublisher = true;
+        while (queueType.getSize(queueService) > 0 && !isSessionValid(candidateSession) && attempts < maxRetries) {
+            candidateId = queueType.pop(queueService);
+            candidateSession = sessionService.getSession(candidateId);
+            attempts++;
+
+            // Validation 1: Cannot be connected to my existing peer (prevent circular dependency)
+            String myConnectedPeer = queueType.getConnectedPeer(myPeerSession);
+            if (myConnectedPeer != null && !isPeerAvailable(candidateId, myConnectedPeer)) {
+                log.warn("Peer not available due to circular dependency - candidate: {}, myConnectedPeer: {}",
+                        candidateId, myConnectedPeer);
+                peerToRestore = candidateId;
+                candidateId = null;
+                candidateSession = null;
+                continue;
             }
 
-            if (publisherId != null && publisherId.equals(session.getId())) {
-                publisherId = null;
+            // Validation 2: Cannot be myself (prevent self-matching)
+            if (candidateId != null && candidateId.equals(myId)) {
+                log.debug("Skipping self-match - peerId: {}", candidateId);
                 needRestoreMine = true;
+                candidateId = null;
+                candidateSession = null;
+                continue;
+            }
+
+            // If session is invalid, continue to next candidate
+            if (!isSessionValid(candidateSession)) {
+                log.debug("Invalid session found in queue - peerId: {}", candidateId);
+                candidateId = null;
+                candidateSession = null;
             }
         }
 
-        if (needRestorePublisher) queueService.addToPublishQueue(peerSession.getSubscriber());
-        if (needRestoreMine) queueService.addToPublishQueue(session.getId());
+        // Restore peers back to queue if needed
+        if (peerToRestore != null) {
+            queueType.add(queueService, peerToRestore);
+        }
+        if (needRestoreMine) {
+            queueType.add(queueService, myId);
+        }
 
-        if (publisherId == null || publisherSession == null) {
-            log.info("❌ No publisher in publish queue");
+        if (candidateId == null || candidateSession == null) {
+            log.info("❌ No waiting peer in {} queue", queueType);
             return null;
         }
 
-        return publisherId;
+        return candidateSession;
     }
 
     private void match(String publisherId, String subscriberId) {

--- a/src/main/java/com/koa/sws/service/MatchService.java
+++ b/src/main/java/com/koa/sws/service/MatchService.java
@@ -2,7 +2,6 @@ package com.koa.sws.service;
 
 import com.koa.sws.model.MessageType;
 import com.koa.sws.model.PeerSession;
-import com.koa.sws.model.QueueType;
 import com.koa.sws.model.SignalMessage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -97,7 +96,7 @@ public class MatchService {
 
         WebSocketSession publisherSession = sessionService.getSession(publisherId);
         PeerSession publisherPeerSession = sessionService.getPeerSession(publisherId);
-        if (!isSessionValid(publisherSession) || publisherPeerSession == null) {
+        if (!sessionService.isSessionValid(publisherSession) || publisherPeerSession == null) {
             log.warn("Publisher session not found: {}", publisherId);
             return;
         }
@@ -122,7 +121,7 @@ public class MatchService {
         WebSocketSession subscriberSession = sessionService.getSession(subscriberId);
         PeerSession subscriberPeerSession = sessionService.getPeerSession(subscriberId);
 
-        if (!isSessionValid(subscriberSession) || subscriberPeerSession == null) {
+        if (!sessionService.isSessionValid(subscriberSession) || subscriberPeerSession == null) {
             log.warn("Subscriber session not found: {}", subscriberId);
             return;
         }
@@ -167,7 +166,7 @@ public class MatchService {
         long maxRetries = queueType.getSize(queueService);
         long attempts = 0;
 
-        while (queueType.getSize(queueService) > 0 && !isSessionValid(candidateSession) && attempts < maxRetries) {
+        while (queueType.getSize(queueService) > 0 && !sessionService.isSessionValid(candidateSession) && attempts < maxRetries) {
             candidateId = queueType.pop(queueService);
             candidateSession = sessionService.getSession(candidateId);
             attempts++;
@@ -193,7 +192,7 @@ public class MatchService {
             }
 
             // If session is invalid, continue to next candidate
-            if (!isSessionValid(candidateSession)) {
+            if (!sessionService.isSessionValid(candidateSession)) {
                 log.debug("Invalid session found in queue - peerId: {}", candidateId);
                 candidateId = null;
                 candidateSession = null;
@@ -221,7 +220,7 @@ public class MatchService {
         // 1. find Session
         WebSocketSession publisherSession = sessionService.getSession(publisherId);
         WebSocketSession subscriberSession = sessionService.getSession(subscriberId);
-        if (!isSessionValid(subscriberSession) || !isSessionValid(publisherSession)) {
+        if (!sessionService.isSessionValid(subscriberSession) || !sessionService.isSessionValid(publisherSession)) {
             log.info("Session not active: {} <-> {}", subscriberId, publisherId);
             return;
         }
@@ -240,7 +239,4 @@ public class MatchService {
         return targetPeerId != null && myPeerId != null && !targetPeerId.equals(myPeerId);
     }
 
-    private boolean isSessionValid(WebSocketSession session) {
-        return session != null && session.isOpen();
-    }
 }

--- a/src/main/java/com/koa/sws/service/MatchService.java
+++ b/src/main/java/com/koa/sws/service/MatchService.java
@@ -1,6 +1,5 @@
 package com.koa.sws.service;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.koa.sws.model.MessageType;
 import com.koa.sws.model.PeerSession;
 import com.koa.sws.model.QueueType;
@@ -8,10 +7,7 @@ import com.koa.sws.model.SignalMessage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-import org.springframework.web.socket.TextMessage;
 import org.springframework.web.socket.WebSocketSession;
-
-import java.io.IOException;
 
 @Slf4j
 @Service
@@ -20,7 +16,7 @@ public class MatchService {
 
     private final SessionService sessionService;
     private final RedisQueueService queueService;
-    private final ObjectMapper objectMapper;
+    private final SignalMessageRelayService relayService;
 
     /**
      * 사용자 등록
@@ -82,27 +78,19 @@ public class MatchService {
     }
 
     /**
-     * 메세지 중계 (OFFER, ANSWER, ICE)
+     * 메시지 중계 (OFFER, ANSWER, ICE)
+     * Delegates to SignalMessageRelayService
      */
     public void relaySignalMessage(SignalMessage message) {
+        relayService.relaySignalMessage(message);
+    }
 
-        String fromId = message.getMyId();     // 메시지 보낸 사람
-        String toId = message.getTargetId();   // 전달해야 할 상대방
-
-        if (toId == null) {
-            log.warn("relay failed: targetId is null. fromId={}", fromId);
-            return;
-        }
-
-        WebSocketSession targetSession = sessionService.getSession(toId);
-        if (!isSessionValid(targetSession)) {
-            log.warn("relay failed: target session invalid. targetId={}", toId);
-            return;
-        }
-
-        // 그대로 상대에게 메시지 전달
-        sendMessage(targetSession, message);
-        log.info("🔁 Relayed {} from {} → {}", message.getType(), fromId, toId);
+    /**
+     * WebSocket 메시지 전송
+     * Delegates to SignalMessageRelayService
+     */
+    public void sendMessage(WebSocketSession session, SignalMessage message) {
+        relayService.sendMessage(session, message);
     }
 
     //
@@ -251,15 +239,6 @@ public class MatchService {
         sessionService.updateSubscriber(publisherId, subscriberId);
         sessionService.updatePublisher(subscriberId, publisherId);
         log.info("📤 Sent MATCH message) publisher: {}, subscriber: {}", publisherId, subscriberId);
-    }
-
-    public void sendMessage(WebSocketSession session, SignalMessage message) {
-        try {
-            String json = objectMapper.writeValueAsString(message);
-            session.sendMessage(new TextMessage(json));
-        } catch (IOException e) {
-            log.error("Failed to send message type {}: {}", message.getType(), e.getMessage());
-        }
     }
 
     private boolean isPeerAvailable(String targetPeerId, String myPeerId) {

--- a/src/main/java/com/koa/sws/service/QueueType.java
+++ b/src/main/java/com/koa/sws/service/QueueType.java
@@ -1,10 +1,8 @@
-package com.koa.sws.model;
+package com.koa.sws.service;
 
-import com.koa.sws.service.RedisQueueService;
+import com.koa.sws.model.PeerSession;
 
-import java.util.function.Consumer;
 import java.util.function.Function;
-import java.util.function.Supplier;
 
 public enum QueueType {
     PUBLISHER(

--- a/src/main/java/com/koa/sws/service/QueueType.java
+++ b/src/main/java/com/koa/sws/service/QueueType.java
@@ -1,6 +1,6 @@
 package com.koa.sws.service;
 
-import com.koa.sws.model.PeerSession;
+import com.koa.sws.model.PeerRelation;
 
 import java.util.function.Function;
 
@@ -9,24 +9,24 @@ public enum QueueType {
             RedisQueueService::popFromPublishQueue,
             RedisQueueService::addToPublishQueue,
             RedisQueueService::getPublishQueueSize,
-            PeerSession::getSubscriber
+            PeerRelation::getSubscriber
     ),
     SUBSCRIBER(
             RedisQueueService::popFromSubscribeQueue,
             RedisQueueService::addToSubscribeQueue,
             RedisQueueService::getSubscribeQueueSize,
-            PeerSession::getPublisher
+            PeerRelation::getPublisher
     );
 
     private final Function<RedisQueueService, String> popFunction;
     private final java.util.function.BiConsumer<RedisQueueService, String> addFunction;
     private final Function<RedisQueueService, Long> sizeFunction;
-    private final Function<PeerSession, String> peerGetter;
+    private final Function<PeerRelation, String> peerGetter;
 
     QueueType(Function<RedisQueueService, String> popFunction,
               java.util.function.BiConsumer<RedisQueueService, String> addFunction,
               Function<RedisQueueService, Long> sizeFunction,
-              Function<PeerSession, String> peerGetter) {
+              Function<PeerRelation, String> peerGetter) {
         this.popFunction = popFunction;
         this.addFunction = addFunction;
         this.sizeFunction = sizeFunction;
@@ -45,7 +45,7 @@ public enum QueueType {
         return sizeFunction.apply(queueService);
     }
 
-    public String getConnectedPeer(PeerSession peerSession) {
-        return peerGetter.apply(peerSession);
+    public String getConnectedPeer(PeerRelation peerRelation) {
+        return peerGetter.apply(peerRelation);
     }
 }

--- a/src/main/java/com/koa/sws/service/RedisQueueService.java
+++ b/src/main/java/com/koa/sws/service/RedisQueueService.java
@@ -1,6 +1,7 @@
 package com.koa.sws.service;
 
 import com.koa.sws.aop.DistributedLock;
+import com.koa.sws.constant.RedisKeyConstants;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -13,39 +14,36 @@ public class RedisQueueService {
 
     private final RedisTemplate<String, String> redisTemplate;
 
-    private static final String PUBLISH_QUEUE = "sws:publishQueue";
-    private static final String SUBSCRIBE_QUEUE = "sws:subscribeQueue";
-
     public void addToPublishQueue(String peerId) {
-        log.info("🔫 ADD Publisher queue: {}", peerId);
-        enqueue(getPublishQueueName(), peerId);
+        log.info("Adding to publisher queue - peerId: {}", peerId);
+        enqueue(RedisKeyConstants.PUBLISH_QUEUE, peerId);
     }
 
     public void addToSubscribeQueue(String peerId) {
-        log.info("🔫 ADD Subscriber queue: {}", peerId);
-        enqueue(getSubscribeQueueName(), peerId);
+        log.info("Adding to subscriber queue - peerId: {}", peerId);
+        enqueue(RedisKeyConstants.SUBSCRIBE_QUEUE, peerId);
     }
 
     @DistributedLock(key = "'publishQueue'")
     public String popFromPublishQueue() {
-        String peerId = dequeue(getPublishQueueName());
-        log.info("🦷 POP Publisher queue: {}", peerId);
+        String peerId = dequeue(RedisKeyConstants.PUBLISH_QUEUE);
+        log.info("Popped from publisher queue - peerId: {}", peerId);
         return peerId;
     }
 
     @DistributedLock(key = "'subscribeQueue'")
     public String popFromSubscribeQueue() {
-        String peerId = dequeue(getSubscribeQueueName());
-        log.info("🦷 POP Subscriber queue: {}", peerId);
+        String peerId = dequeue(RedisKeyConstants.SUBSCRIBE_QUEUE);
+        log.info("Popped from subscriber queue - peerId: {}", peerId);
         return peerId;
     }
 
     public Long getPublishQueueSize() {
-        return getQueueSize(getPublishQueueName());
+        return getQueueSize(RedisKeyConstants.PUBLISH_QUEUE);
     }
 
     public Long getSubscribeQueueSize() {
-        return getQueueSize(getSubscribeQueueName());
+        return getQueueSize(RedisKeyConstants.SUBSCRIBE_QUEUE);
     }
 
     private Long getQueueSize(String queue) {
@@ -58,13 +56,5 @@ public class RedisQueueService {
 
     private String dequeue(String queue) {
         return redisTemplate.opsForList().leftPop(queue);
-    }
-
-    private String getPublishQueueName() {
-        return PUBLISH_QUEUE;
-    }
-
-    private String getSubscribeQueueName() {
-        return SUBSCRIBE_QUEUE;
     }
 }

--- a/src/main/java/com/koa/sws/service/SessionService.java
+++ b/src/main/java/com/koa/sws/service/SessionService.java
@@ -1,6 +1,6 @@
 package com.koa.sws.service;
 
-import com.koa.sws.model.PeerSession;
+import com.koa.sws.model.PeerRelation;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.web.socket.WebSocketSession;
@@ -13,37 +13,36 @@ import java.util.concurrent.ConcurrentHashMap;
 public class SessionService {
 
     private final Map<String, WebSocketSession> websocketSessions = new ConcurrentHashMap<>();
-    private final Map<String, PeerSession> peerSessions = new ConcurrentHashMap<>();
+    private final Map<String, PeerRelation> peerRelations = new ConcurrentHashMap<>();
 
     public String register(WebSocketSession session) {
         websocketSessions.put(session.getId(), session);
-        peerSessions.put(session.getId(), new PeerSession(session.getId()));
+        peerRelations.put(session.getId(), new PeerRelation(session.getId()));
         return session.getId();
     }
 
-    public PeerSession remove(String sessionId) {
-        PeerSession peer = peerSessions.remove(sessionId);
+    public PeerRelation remove(String sessionId) {
+        PeerRelation relation = peerRelations.remove(sessionId);
         websocketSessions.remove(sessionId);
-
-        return peer;
+        return relation;
     }
 
     public void updatePublisher(String peerId, String publisherId) {
-        PeerSession peerSession = peerSessions.get(peerId);
-        if (peerSession == null) {
-            log.warn("PeerSession not found for peerId: {}", peerId);
+        PeerRelation relation = peerRelations.get(peerId);
+        if (relation == null) {
+            log.warn("PeerRelation not found for peerId: {}", peerId);
             return;
         }
-        peerSession.setPublisher(publisherId);
+        relation.setPublisher(publisherId);
     }
 
     public void updateSubscriber(String peerId, String subscriberId) {
-        PeerSession peerSession = peerSessions.get(peerId);
-        if (peerSession == null) {
-            log.warn("PeerSession not found for peerId: {}", peerId);
+        PeerRelation relation = peerRelations.get(peerId);
+        if (relation == null) {
+            log.warn("PeerRelation not found for peerId: {}", peerId);
             return;
         }
-        peerSession.setSubscriber(subscriberId);
+        relation.setSubscriber(subscriberId);
     }
 
     public WebSocketSession getSession(String peerId) {
@@ -51,9 +50,9 @@ public class SessionService {
         return websocketSessions.get(peerId);
     }
 
-    public PeerSession getPeerSession(String peerId) {
+    public PeerRelation getPeerRelation(String peerId) {
         if (peerId == null) return null;
-        return peerSessions.get(peerId);
+        return peerRelations.get(peerId);
     }
 
     public boolean isSessionValid(WebSocketSession session) {

--- a/src/main/java/com/koa/sws/service/SessionService.java
+++ b/src/main/java/com/koa/sws/service/SessionService.java
@@ -31,11 +31,19 @@ public class SessionService {
 
     public void updatePublisher(String peerId, String publisherId) {
         PeerSession peerSession = peerSessions.get(peerId);
+        if (peerSession == null) {
+            log.warn("PeerSession not found for peerId: {}", peerId);
+            return;
+        }
         peerSession.setPublisher(publisherId);
     }
 
     public void updateSubscriber(String peerId, String subscriberId) {
         PeerSession peerSession = peerSessions.get(peerId);
+        if (peerSession == null) {
+            log.warn("PeerSession not found for peerId: {}", peerId);
+            return;
+        }
         peerSession.setSubscriber(subscriberId);
     }
 

--- a/src/main/java/com/koa/sws/service/SessionService.java
+++ b/src/main/java/com/koa/sws/service/SessionService.java
@@ -58,4 +58,8 @@ public class SessionService {
     public boolean isSessionValid(WebSocketSession session) {
         return session != null && session.isOpen();
     }
+
+    public int getSessionCount() {
+        return websocketSessions.size();
+    }
 }

--- a/src/main/java/com/koa/sws/service/SessionService.java
+++ b/src/main/java/com/koa/sws/service/SessionService.java
@@ -60,4 +60,8 @@ public class SessionService {
     public Collection<WebSocketSession> getAllSessions() {
         return websocketSessions.values();
     }
+
+    public boolean isSessionValid(WebSocketSession session) {
+        return session != null && session.isOpen();
+    }
 }

--- a/src/main/java/com/koa/sws/service/SessionService.java
+++ b/src/main/java/com/koa/sws/service/SessionService.java
@@ -5,7 +5,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.web.socket.WebSocketSession;
 
-import java.util.Collection;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -55,10 +54,6 @@ public class SessionService {
     public PeerSession getPeerSession(String peerId) {
         if (peerId == null) return null;
         return peerSessions.get(peerId);
-    }
-
-    public Collection<WebSocketSession> getAllSessions() {
-        return websocketSessions.values();
     }
 
     public boolean isSessionValid(WebSocketSession session) {

--- a/src/main/java/com/koa/sws/service/SignalMessageRelayService.java
+++ b/src/main/java/com/koa/sws/service/SignalMessageRelayService.java
@@ -1,0 +1,58 @@
+package com.koa.sws.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.koa.sws.model.SignalMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketSession;
+
+import java.io.IOException;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SignalMessageRelayService {
+
+    private final SessionService sessionService;
+    private final ObjectMapper objectMapper;
+
+    /**
+     * 메시지 중계 (OFFER, ANSWER, ICE)
+     */
+    public void relaySignalMessage(SignalMessage message) {
+        String fromId = message.getMyId();
+        String toId = message.getTargetId();
+
+        if (toId == null) {
+            log.warn("relay failed: targetId is null. fromId={}", fromId);
+            return;
+        }
+
+        WebSocketSession targetSession = sessionService.getSession(toId);
+        if (!isSessionValid(targetSession)) {
+            log.warn("relay failed: target session invalid. targetId={}", toId);
+            return;
+        }
+
+        sendMessage(targetSession, message);
+        log.info("🔁 Relayed {} from {} → {}", message.getType(), fromId, toId);
+    }
+
+    /**
+     * WebSocket 메시지 전송
+     */
+    public void sendMessage(WebSocketSession session, SignalMessage message) {
+        try {
+            String json = objectMapper.writeValueAsString(message);
+            session.sendMessage(new TextMessage(json));
+        } catch (IOException e) {
+            log.error("Failed to send message type {}: {}", message.getType(), e.getMessage());
+        }
+    }
+
+    private boolean isSessionValid(WebSocketSession session) {
+        return session != null && session.isOpen();
+    }
+}

--- a/src/main/java/com/koa/sws/service/SignalMessageRelayService.java
+++ b/src/main/java/com/koa/sws/service/SignalMessageRelayService.java
@@ -26,18 +26,18 @@ public class SignalMessageRelayService {
         String toId = message.getTargetId();
 
         if (toId == null) {
-            log.warn("relay failed: targetId is null. fromId={}", fromId);
+            log.warn("Relay failed: targetId is null - fromId: {}", fromId);
             return;
         }
 
         WebSocketSession targetSession = sessionService.getSession(toId);
         if (!isSessionValid(targetSession)) {
-            log.warn("relay failed: target session invalid. targetId={}", toId);
+            log.warn("Relay failed: target session invalid - targetId: {}", toId);
             return;
         }
 
         sendMessage(targetSession, message);
-        log.info("🔁 Relayed {} from {} → {}", message.getType(), fromId, toId);
+        log.info("Message relayed - type: {}, from: {} to: {}", message.getType(), fromId, toId);
     }
 
     /**
@@ -48,7 +48,7 @@ public class SignalMessageRelayService {
             String json = objectMapper.writeValueAsString(message);
             session.sendMessage(new TextMessage(json));
         } catch (IOException e) {
-            log.error("Failed to send message type {}: {}", message.getType(), e.getMessage());
+            log.error("Failed to send message - type: {}, error: {}", message.getType(), e.getMessage());
         }
     }
 

--- a/src/main/java/com/koa/sws/service/SignalMessageRelayService.java
+++ b/src/main/java/com/koa/sws/service/SignalMessageRelayService.java
@@ -31,7 +31,7 @@ public class SignalMessageRelayService {
         }
 
         WebSocketSession targetSession = sessionService.getSession(toId);
-        if (!isSessionValid(targetSession)) {
+        if (!sessionService.isSessionValid(targetSession)) {
             log.warn("Relay failed: target session invalid - targetId: {}", toId);
             return;
         }
@@ -52,7 +52,4 @@ public class SignalMessageRelayService {
         }
     }
 
-    private boolean isSessionValid(WebSocketSession session) {
-        return session != null && session.isOpen();
-    }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,5 +9,8 @@ spring:
       password: ${REDIS_PASSWORD}
       timeout: ${REDIS_TIMEOUT:60000}
 
+websocket:
+  allowed-origins: ${WEBSOCKET_ALLOWED_ORIGINS:http://localhost:3000,${FRONT_URL}}
+
 front:
   url: ${FRONT_URL}

--- a/src/test/java/com/koa/sws/model/QueueTypeTest.java
+++ b/src/test/java/com/koa/sws/model/QueueTypeTest.java
@@ -1,0 +1,142 @@
+package com.koa.sws.model;
+
+import com.koa.sws.service.RedisQueueService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class QueueTypeTest {
+
+    @Mock
+    private RedisQueueService queueService;
+
+    private PeerSession peerSession;
+
+    @BeforeEach
+    void setUp() {
+        peerSession = new PeerSession("peer-1");
+    }
+
+    @Test
+    @DisplayName("PUBLISHER 타입 - pop 메서드 호출")
+    void publisher_ShouldPopFromPublishQueue() {
+        // given
+        when(queueService.popFromPublishQueue()).thenReturn("publisher-1");
+
+        // when
+        String result = QueueType.PUBLISHER.pop(queueService);
+
+        // then
+        assertThat(result).isEqualTo("publisher-1");
+        verify(queueService).popFromPublishQueue();
+    }
+
+    @Test
+    @DisplayName("PUBLISHER 타입 - add 메서드 호출")
+    void publisher_ShouldAddToPublishQueue() {
+        // when
+        QueueType.PUBLISHER.add(queueService, "publisher-1");
+
+        // then
+        verify(queueService).addToPublishQueue("publisher-1");
+    }
+
+    @Test
+    @DisplayName("PUBLISHER 타입 - getSize 메서드 호출")
+    void publisher_ShouldGetPublishQueueSize() {
+        // given
+        when(queueService.getPublishQueueSize()).thenReturn(5L);
+
+        // when
+        Long size = QueueType.PUBLISHER.getSize(queueService);
+
+        // then
+        assertThat(size).isEqualTo(5L);
+        verify(queueService).getPublishQueueSize();
+    }
+
+    @Test
+    @DisplayName("PUBLISHER 타입 - getConnectedPeer는 subscriber를 반환")
+    void publisher_ShouldReturnSubscriberAsConnectedPeer() {
+        // given
+        peerSession.setSubscriber("subscriber-1");
+
+        // when
+        String connectedPeer = QueueType.PUBLISHER.getConnectedPeer(peerSession);
+
+        // then
+        assertThat(connectedPeer).isEqualTo("subscriber-1");
+    }
+
+    @Test
+    @DisplayName("SUBSCRIBER 타입 - pop 메서드 호출")
+    void subscriber_ShouldPopFromSubscribeQueue() {
+        // given
+        when(queueService.popFromSubscribeQueue()).thenReturn("subscriber-1");
+
+        // when
+        String result = QueueType.SUBSCRIBER.pop(queueService);
+
+        // then
+        assertThat(result).isEqualTo("subscriber-1");
+        verify(queueService).popFromSubscribeQueue();
+    }
+
+    @Test
+    @DisplayName("SUBSCRIBER 타입 - add 메서드 호출")
+    void subscriber_ShouldAddToSubscribeQueue() {
+        // when
+        QueueType.SUBSCRIBER.add(queueService, "subscriber-1");
+
+        // then
+        verify(queueService).addToSubscribeQueue("subscriber-1");
+    }
+
+    @Test
+    @DisplayName("SUBSCRIBER 타입 - getSize 메서드 호출")
+    void subscriber_ShouldGetSubscribeQueueSize() {
+        // given
+        when(queueService.getSubscribeQueueSize()).thenReturn(10L);
+
+        // when
+        Long size = QueueType.SUBSCRIBER.getSize(queueService);
+
+        // then
+        assertThat(size).isEqualTo(10L);
+        verify(queueService).getSubscribeQueueSize();
+    }
+
+    @Test
+    @DisplayName("SUBSCRIBER 타입 - getConnectedPeer는 publisher를 반환")
+    void subscriber_ShouldReturnPublisherAsConnectedPeer() {
+        // given
+        peerSession.setPublisher("publisher-1");
+
+        // when
+        String connectedPeer = QueueType.SUBSCRIBER.getConnectedPeer(peerSession);
+
+        // then
+        assertThat(connectedPeer).isEqualTo("publisher-1");
+    }
+
+    @Test
+    @DisplayName("PUBLISHER와 SUBSCRIBER는 서로 다른 큐를 사용")
+    void publisherAndSubscriber_ShouldUseDifferentQueues() {
+        // when
+        QueueType.PUBLISHER.add(queueService, "peer-1");
+        QueueType.SUBSCRIBER.add(queueService, "peer-2");
+
+        // then
+        verify(queueService).addToPublishQueue("peer-1");
+        verify(queueService).addToSubscribeQueue("peer-2");
+        verify(queueService, never()).addToPublishQueue("peer-2");
+        verify(queueService, never()).addToSubscribeQueue("peer-1");
+    }
+}

--- a/src/test/java/com/koa/sws/service/MatchServiceTest.java
+++ b/src/test/java/com/koa/sws/service/MatchServiceTest.java
@@ -1,0 +1,270 @@
+package com.koa.sws.service;
+
+import com.koa.sws.model.MessageType;
+import com.koa.sws.model.PeerSession;
+import com.koa.sws.model.SignalMessage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.socket.WebSocketSession;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class MatchServiceTest {
+
+    @Mock
+    private SessionService sessionService;
+
+    @Mock
+    private RedisQueueService queueService;
+
+    @Mock
+    private SignalMessageRelayService relayService;
+
+    @Mock
+    private WebSocketSession publisherSession;
+
+    @Mock
+    private WebSocketSession subscriberSession;
+
+    @InjectMocks
+    private MatchService matchService;
+
+    private PeerSession publisherPeerSession;
+    private PeerSession subscriberPeerSession;
+
+    @BeforeEach
+    void setUp() {
+        publisherPeerSession = new PeerSession("publisher-1");
+        subscriberPeerSession = new PeerSession("subscriber-1");
+
+        lenient().when(publisherSession.getId()).thenReturn("publisher-1");
+        lenient().when(subscriberSession.getId()).thenReturn("subscriber-1");
+        lenient().when(publisherSession.isOpen()).thenReturn(true);
+        lenient().when(subscriberSession.isOpen()).thenReturn(true);
+    }
+
+    @Test
+    @DisplayName("메시지 중계 - relayService에 위임")
+    void relaySignalMessage_ShouldDelegateToRelayService() {
+        // given
+        SignalMessage message = new SignalMessage(MessageType.OFFER, "sender", "receiver", "data");
+
+        // when
+        matchService.relaySignalMessage(message);
+
+        // then
+        verify(relayService).relaySignalMessage(message);
+    }
+
+    @Test
+    @DisplayName("메시지 전송 - relayService에 위임")
+    void sendMessage_ShouldDelegateToRelayService() {
+        // given
+        SignalMessage message = new SignalMessage(MessageType.PUBLISH, "pub", "sub");
+
+        // when
+        matchService.sendMessage(publisherSession, message);
+
+        // then
+        verify(relayService).sendMessage(publisherSession, message);
+    }
+
+    @Test
+    @DisplayName("Publisher 등록 - 대기 중인 subscriber가 없으면 큐에 추가")
+    void registerAsPublisher_ShouldAddToQueueWhenNoSubscriberIsWaiting() {
+        // given
+        when(sessionService.getPeerSession("publisher-1")).thenReturn(publisherPeerSession);
+        when(queueService.getSubscribeQueueSize()).thenReturn(0L);
+
+        // when
+        matchService.registerAsPublisher(publisherSession);
+
+        // then
+        verify(queueService).addToPublishQueue("publisher-1");
+        verify(relayService, never()).sendMessage(any(), any());
+    }
+
+    @Test
+    @DisplayName("Subscriber 등록 - 대기 중인 publisher가 없으면 큐에 추가")
+    void registerAsSubscriber_ShouldAddToQueueWhenNoPublisherIsWaiting() {
+        // given
+        when(sessionService.getPeerSession("subscriber-1")).thenReturn(subscriberPeerSession);
+        when(queueService.getPublishQueueSize()).thenReturn(0L);
+
+        // when
+        matchService.registerAsSubscriber(subscriberSession);
+
+        // then
+        verify(queueService).addToSubscribeQueue("subscriber-1");
+        verify(relayService, never()).sendMessage(any(), any());
+    }
+
+    @Test
+    @DisplayName("Publisher 등록 - 대기 중인 subscriber가 있으면 즉시 매칭 성공")
+    void registerAsPublisher_ShouldMatchSuccessfully() {
+        // given
+        when(sessionService.getPeerSession("publisher-1")).thenReturn(publisherPeerSession);
+        when(sessionService.getSession("subscriber-1")).thenReturn(subscriberSession);
+        when(sessionService.getSession("publisher-1")).thenReturn(publisherSession); // match 메서드에서 필요
+
+        // Queue에서 subscriber를 pop
+        when(queueService.getSubscribeQueueSize()).thenReturn(1L, 0L);
+        when(queueService.popFromSubscribeQueue()).thenReturn("subscriber-1");
+
+        // when
+        matchService.registerAsPublisher(publisherSession);
+
+        // then
+        verify(queueService).popFromSubscribeQueue();
+        verify(sessionService).updateSubscriber("publisher-1", "subscriber-1");
+        verify(sessionService).updatePublisher("subscriber-1", "publisher-1");
+        verify(relayService, times(2)).sendMessage(any(WebSocketSession.class), any(SignalMessage.class));
+    }
+
+    @Test
+    @DisplayName("Subscriber 등록 - 대기 중인 publisher가 있으면 즉시 매칭 성공")
+    void registerAsSubscriber_ShouldMatchSuccessfully() {
+        // given
+        when(sessionService.getPeerSession("subscriber-1")).thenReturn(subscriberPeerSession);
+        when(sessionService.getSession("publisher-1")).thenReturn(publisherSession);
+        when(sessionService.getSession("subscriber-1")).thenReturn(subscriberSession); // match 메서드에서 필요
+
+        // Queue에서 publisher를 pop
+        when(queueService.getPublishQueueSize()).thenReturn(1L, 0L);
+        when(queueService.popFromPublishQueue()).thenReturn("publisher-1");
+
+        // when
+        matchService.registerAsSubscriber(subscriberSession);
+
+        // then
+        verify(queueService).popFromPublishQueue();
+        verify(sessionService).updateSubscriber("publisher-1", "subscriber-1");
+        verify(sessionService).updatePublisher("subscriber-1", "publisher-1");
+        verify(relayService, times(2)).sendMessage(any(WebSocketSession.class), any(SignalMessage.class));
+    }
+
+    @Test
+    @DisplayName("자기 자신 매칭 방지 - 큐에서 자신을 발견하면 스킵하고 다음 후보 찾기")
+    void getWaitingPeer_ShouldSkipSelfMatch() {
+        // given
+        when(sessionService.getPeerSession("publisher-1")).thenReturn(publisherPeerSession);
+        when(sessionService.getSession("subscriber-1")).thenReturn(subscriberSession);
+        when(sessionService.getSession("publisher-1")).thenReturn(publisherSession);
+
+        // 큐에서 먼저 자기 자신이 나오고, 그 다음 유효한 subscriber가 나옴
+        when(queueService.getSubscribeQueueSize()).thenReturn(2L, 1L, 0L);
+        when(queueService.popFromSubscribeQueue())
+                .thenReturn("publisher-1")  // 자기 자신 (스킵되어야 함)
+                .thenReturn("subscriber-1"); // 유효한 subscriber
+
+        // when
+        matchService.registerAsPublisher(publisherSession);
+
+        // then
+        verify(queueService, times(2)).popFromSubscribeQueue();
+        verify(queueService).addToSubscribeQueue("publisher-1"); // 자신을 큐에 복원
+        verify(sessionService).updateSubscriber("publisher-1", "subscriber-1"); // 결국 subscriber-1과 매칭
+    }
+
+
+    @Test
+    @DisplayName("피어 해제 - publisher에게 LEAVE 메시지 전송 및 재매칭")
+    void unregisterPeer_ShouldNotifyPublisherAndRematch() {
+        // given
+        subscriberPeerSession.setPublisher("publisher-1");
+        when(sessionService.remove("subscriber-1")).thenReturn(subscriberPeerSession);
+        when(sessionService.getSession("publisher-1")).thenReturn(publisherSession);
+        when(sessionService.getPeerSession("publisher-1")).thenReturn(publisherPeerSession);
+        when(queueService.getSubscribeQueueSize()).thenReturn(0L);
+
+        // when
+        matchService.unregisterPeer("subscriber-1");
+
+        // then
+        verify(relayService).sendMessage(eq(publisherSession), argThat(msg ->
+            msg.getType() == MessageType.LEAVE &&
+            msg.getMyId().equals("publisher-1") &&
+            msg.getTargetId().equals("subscriber-1")
+        ));
+        verify(sessionService).updateSubscriber("publisher-1", null);
+        verify(queueService).addToPublishQueue("publisher-1"); // 새 subscriber 대기를 위해 큐에 추가
+    }
+
+    @Test
+    @DisplayName("피어 해제 - subscriber에게 LEAVE 메시지 전송 및 재매칭")
+    void unregisterPeer_ShouldNotifySubscriberAndRematch() {
+        // given
+        publisherPeerSession.setSubscriber("subscriber-1");
+        when(sessionService.remove("publisher-1")).thenReturn(publisherPeerSession);
+        when(sessionService.getSession("subscriber-1")).thenReturn(subscriberSession);
+        when(sessionService.getPeerSession("subscriber-1")).thenReturn(subscriberPeerSession);
+        when(queueService.getPublishQueueSize()).thenReturn(0L);
+
+        // when
+        matchService.unregisterPeer("publisher-1");
+
+        // then
+        verify(relayService).sendMessage(eq(subscriberSession), argThat(msg ->
+            msg.getType() == MessageType.LEAVE &&
+            msg.getMyId().equals("subscriber-1") &&
+            msg.getTargetId().equals("publisher-1")
+        ));
+        verify(sessionService).updatePublisher("subscriber-1", null);
+        verify(queueService).addToSubscribeQueue("subscriber-1"); // 새 publisher 대기를 위해 큐에 추가
+    }
+
+    @Test
+    @DisplayName("피어 해제 - 대기 중인 새로운 피어가 있으면 즉시 재매칭")
+    void unregisterPeer_ShouldRematchWithWaitingPeer() {
+        // given
+        subscriberPeerSession.setPublisher("publisher-1");
+        WebSocketSession newSubscriberSession = mock(WebSocketSession.class);
+        when(newSubscriberSession.getId()).thenReturn("new-subscriber");
+        when(newSubscriberSession.isOpen()).thenReturn(true);
+
+        when(sessionService.remove("subscriber-1")).thenReturn(subscriberPeerSession);
+        when(sessionService.getSession("publisher-1")).thenReturn(publisherSession);
+        when(sessionService.getPeerSession("publisher-1")).thenReturn(publisherPeerSession);
+        when(sessionService.getSession("new-subscriber")).thenReturn(newSubscriberSession);
+
+        // 큐에 새로운 subscriber가 대기 중
+        when(queueService.getSubscribeQueueSize()).thenReturn(1L, 0L);
+        when(queueService.popFromSubscribeQueue()).thenReturn("new-subscriber");
+
+        // when
+        matchService.unregisterPeer("subscriber-1");
+
+        // then
+        verify(relayService).sendMessage(eq(publisherSession), argThat(msg ->
+            msg.getType() == MessageType.LEAVE
+        ));
+        verify(sessionService).updateSubscriber("publisher-1", null);
+        verify(queueService).popFromSubscribeQueue();
+        verify(sessionService).updateSubscriber("publisher-1", "new-subscriber"); // 새 subscriber와 재매칭
+        verify(queueService, never()).addToPublishQueue("publisher-1"); // 재매칭 성공했으므로 큐에 추가 안 함
+    }
+
+    @Test
+    @DisplayName("피어 해제 - 존재하지 않는 피어 해제 시 경고 로그만 출력")
+    void unregisterPeer_ShouldLogWarningWhenPeerNotFound() {
+        // given
+        when(sessionService.remove("non-existent-peer")).thenReturn(null);
+
+        // when
+        matchService.unregisterPeer("non-existent-peer");
+
+        // then
+        verify(sessionService).remove("non-existent-peer");
+        verify(relayService, never()).sendMessage(any(), any());
+        verify(queueService, never()).addToPublishQueue(anyString());
+        verify(queueService, never()).addToSubscribeQueue(anyString());
+    }
+
+}

--- a/src/test/java/com/koa/sws/service/MatchServiceTest.java
+++ b/src/test/java/com/koa/sws/service/MatchServiceTest.java
@@ -28,6 +28,9 @@ class MatchServiceTest {
     private SignalMessageRelayService relayService;
 
     @Mock
+    private FindPeerService findPeerService;
+
+    @Mock
     private WebSocketSession publisherSession;
 
     @Mock
@@ -51,37 +54,10 @@ class MatchServiceTest {
     }
 
     @Test
-    @DisplayName("메시지 중계 - relayService에 위임")
-    void relaySignalMessage_ShouldDelegateToRelayService() {
-        // given
-        SignalMessage message = new SignalMessage(MessageType.OFFER, "sender", "receiver", "data");
-
-        // when
-        matchService.relaySignalMessage(message);
-
-        // then
-        verify(relayService).relaySignalMessage(message);
-    }
-
-    @Test
-    @DisplayName("메시지 전송 - relayService에 위임")
-    void sendMessage_ShouldDelegateToRelayService() {
-        // given
-        SignalMessage message = new SignalMessage(MessageType.PUBLISH, "pub", "sub");
-
-        // when
-        matchService.sendMessage(publisherSession, message);
-
-        // then
-        verify(relayService).sendMessage(publisherSession, message);
-    }
-
-    @Test
     @DisplayName("Publisher 등록 - 대기 중인 subscriber가 없으면 큐에 추가")
     void registerAsPublisher_ShouldAddToQueueWhenNoSubscriberIsWaiting() {
         // given
-        when(sessionService.getPeerSession("publisher-1")).thenReturn(publisherPeerSession);
-        when(queueService.getSubscribeQueueSize()).thenReturn(0L);
+        when(findPeerService.findWaitingSubscriber(publisherSession)).thenReturn(null);
 
         // when
         matchService.registerAsPublisher(publisherSession);
@@ -95,8 +71,7 @@ class MatchServiceTest {
     @DisplayName("Subscriber 등록 - 대기 중인 publisher가 없으면 큐에 추가")
     void registerAsSubscriber_ShouldAddToQueueWhenNoPublisherIsWaiting() {
         // given
-        when(sessionService.getPeerSession("subscriber-1")).thenReturn(subscriberPeerSession);
-        when(queueService.getPublishQueueSize()).thenReturn(0L);
+        when(findPeerService.findWaitingPublisher(subscriberSession)).thenReturn(null);
 
         // when
         matchService.registerAsSubscriber(subscriberSession);
@@ -110,19 +85,16 @@ class MatchServiceTest {
     @DisplayName("Publisher 등록 - 대기 중인 subscriber가 있으면 즉시 매칭 성공")
     void registerAsPublisher_ShouldMatchSuccessfully() {
         // given
-        when(sessionService.getPeerSession("publisher-1")).thenReturn(publisherPeerSession);
+        when(findPeerService.findWaitingSubscriber(publisherSession)).thenReturn("subscriber-1");
         when(sessionService.getSession("subscriber-1")).thenReturn(subscriberSession);
-        when(sessionService.getSession("publisher-1")).thenReturn(publisherSession); // match 메서드에서 필요
-
-        // Queue에서 subscriber를 pop
-        when(queueService.getSubscribeQueueSize()).thenReturn(1L, 0L);
-        when(queueService.popFromSubscribeQueue()).thenReturn("subscriber-1");
+        when(sessionService.getSession("publisher-1")).thenReturn(publisherSession);
+        when(sessionService.isSessionValid(publisherSession)).thenReturn(true);
+        when(sessionService.isSessionValid(subscriberSession)).thenReturn(true);
 
         // when
         matchService.registerAsPublisher(publisherSession);
 
         // then
-        verify(queueService).popFromSubscribeQueue();
         verify(sessionService).updateSubscriber("publisher-1", "subscriber-1");
         verify(sessionService).updatePublisher("subscriber-1", "publisher-1");
         verify(relayService, times(2)).sendMessage(any(WebSocketSession.class), any(SignalMessage.class));
@@ -132,47 +104,20 @@ class MatchServiceTest {
     @DisplayName("Subscriber 등록 - 대기 중인 publisher가 있으면 즉시 매칭 성공")
     void registerAsSubscriber_ShouldMatchSuccessfully() {
         // given
-        when(sessionService.getPeerSession("subscriber-1")).thenReturn(subscriberPeerSession);
+        when(findPeerService.findWaitingPublisher(subscriberSession)).thenReturn("publisher-1");
         when(sessionService.getSession("publisher-1")).thenReturn(publisherSession);
-        when(sessionService.getSession("subscriber-1")).thenReturn(subscriberSession); // match 메서드에서 필요
-
-        // Queue에서 publisher를 pop
-        when(queueService.getPublishQueueSize()).thenReturn(1L, 0L);
-        when(queueService.popFromPublishQueue()).thenReturn("publisher-1");
+        when(sessionService.getSession("subscriber-1")).thenReturn(subscriberSession);
+        when(sessionService.isSessionValid(publisherSession)).thenReturn(true);
+        when(sessionService.isSessionValid(subscriberSession)).thenReturn(true);
 
         // when
         matchService.registerAsSubscriber(subscriberSession);
 
         // then
-        verify(queueService).popFromPublishQueue();
         verify(sessionService).updateSubscriber("publisher-1", "subscriber-1");
         verify(sessionService).updatePublisher("subscriber-1", "publisher-1");
         verify(relayService, times(2)).sendMessage(any(WebSocketSession.class), any(SignalMessage.class));
     }
-
-    @Test
-    @DisplayName("자기 자신 매칭 방지 - 큐에서 자신을 발견하면 스킵하고 다음 후보 찾기")
-    void getWaitingPeer_ShouldSkipSelfMatch() {
-        // given
-        when(sessionService.getPeerSession("publisher-1")).thenReturn(publisherPeerSession);
-        when(sessionService.getSession("subscriber-1")).thenReturn(subscriberSession);
-        when(sessionService.getSession("publisher-1")).thenReturn(publisherSession);
-
-        // 큐에서 먼저 자기 자신이 나오고, 그 다음 유효한 subscriber가 나옴
-        when(queueService.getSubscribeQueueSize()).thenReturn(2L, 1L, 0L);
-        when(queueService.popFromSubscribeQueue())
-                .thenReturn("publisher-1")  // 자기 자신 (스킵되어야 함)
-                .thenReturn("subscriber-1"); // 유효한 subscriber
-
-        // when
-        matchService.registerAsPublisher(publisherSession);
-
-        // then
-        verify(queueService, times(2)).popFromSubscribeQueue();
-        verify(queueService).addToSubscribeQueue("publisher-1"); // 자신을 큐에 복원
-        verify(sessionService).updateSubscriber("publisher-1", "subscriber-1"); // 결국 subscriber-1과 매칭
-    }
-
 
     @Test
     @DisplayName("피어 해제 - publisher에게 LEAVE 메시지 전송 및 재매칭")
@@ -182,7 +127,8 @@ class MatchServiceTest {
         when(sessionService.remove("subscriber-1")).thenReturn(subscriberPeerSession);
         when(sessionService.getSession("publisher-1")).thenReturn(publisherSession);
         when(sessionService.getPeerSession("publisher-1")).thenReturn(publisherPeerSession);
-        when(queueService.getSubscribeQueueSize()).thenReturn(0L);
+        when(sessionService.isSessionValid(publisherSession)).thenReturn(true);
+        when(findPeerService.findWaitingSubscriber(publisherSession)).thenReturn(null);
 
         // when
         matchService.unregisterPeer("subscriber-1");
@@ -194,7 +140,7 @@ class MatchServiceTest {
             msg.getTargetId().equals("subscriber-1")
         ));
         verify(sessionService).updateSubscriber("publisher-1", null);
-        verify(queueService).addToPublishQueue("publisher-1"); // 새 subscriber 대기를 위해 큐에 추가
+        verify(queueService).addToPublishQueue("publisher-1");
     }
 
     @Test
@@ -205,7 +151,8 @@ class MatchServiceTest {
         when(sessionService.remove("publisher-1")).thenReturn(publisherPeerSession);
         when(sessionService.getSession("subscriber-1")).thenReturn(subscriberSession);
         when(sessionService.getPeerSession("subscriber-1")).thenReturn(subscriberPeerSession);
-        when(queueService.getPublishQueueSize()).thenReturn(0L);
+        when(sessionService.isSessionValid(subscriberSession)).thenReturn(true);
+        when(findPeerService.findWaitingPublisher(subscriberSession)).thenReturn(null);
 
         // when
         matchService.unregisterPeer("publisher-1");
@@ -217,7 +164,7 @@ class MatchServiceTest {
             msg.getTargetId().equals("publisher-1")
         ));
         verify(sessionService).updatePublisher("subscriber-1", null);
-        verify(queueService).addToSubscribeQueue("subscriber-1"); // 새 publisher 대기를 위해 큐에 추가
+        verify(queueService).addToSubscribeQueue("subscriber-1");
     }
 
     @Test
@@ -226,17 +173,15 @@ class MatchServiceTest {
         // given
         subscriberPeerSession.setPublisher("publisher-1");
         WebSocketSession newSubscriberSession = mock(WebSocketSession.class);
-        when(newSubscriberSession.getId()).thenReturn("new-subscriber");
-        when(newSubscriberSession.isOpen()).thenReturn(true);
+        lenient().when(newSubscriberSession.getId()).thenReturn("new-subscriber");
 
         when(sessionService.remove("subscriber-1")).thenReturn(subscriberPeerSession);
         when(sessionService.getSession("publisher-1")).thenReturn(publisherSession);
         when(sessionService.getPeerSession("publisher-1")).thenReturn(publisherPeerSession);
+        when(sessionService.isSessionValid(publisherSession)).thenReturn(true);
+        when(sessionService.isSessionValid(newSubscriberSession)).thenReturn(true);
         when(sessionService.getSession("new-subscriber")).thenReturn(newSubscriberSession);
-
-        // 큐에 새로운 subscriber가 대기 중
-        when(queueService.getSubscribeQueueSize()).thenReturn(1L, 0L);
-        when(queueService.popFromSubscribeQueue()).thenReturn("new-subscriber");
+        when(findPeerService.findWaitingSubscriber(publisherSession)).thenReturn("new-subscriber");
 
         // when
         matchService.unregisterPeer("subscriber-1");
@@ -246,9 +191,8 @@ class MatchServiceTest {
             msg.getType() == MessageType.LEAVE
         ));
         verify(sessionService).updateSubscriber("publisher-1", null);
-        verify(queueService).popFromSubscribeQueue();
-        verify(sessionService).updateSubscriber("publisher-1", "new-subscriber"); // 새 subscriber와 재매칭
-        verify(queueService, never()).addToPublishQueue("publisher-1"); // 재매칭 성공했으므로 큐에 추가 안 함
+        verify(sessionService).updateSubscriber("publisher-1", "new-subscriber");
+        verify(queueService, never()).addToPublishQueue("publisher-1");
     }
 
     @Test
@@ -266,5 +210,4 @@ class MatchServiceTest {
         verify(queueService, never()).addToPublishQueue(anyString());
         verify(queueService, never()).addToSubscribeQueue(anyString());
     }
-
 }

--- a/src/test/java/com/koa/sws/service/MatchServiceTest.java
+++ b/src/test/java/com/koa/sws/service/MatchServiceTest.java
@@ -1,7 +1,7 @@
 package com.koa.sws.service;
 
 import com.koa.sws.model.MessageType;
-import com.koa.sws.model.PeerSession;
+import com.koa.sws.model.PeerRelation;
 import com.koa.sws.model.SignalMessage;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -39,13 +39,13 @@ class MatchServiceTest {
     @InjectMocks
     private MatchService matchService;
 
-    private PeerSession publisherPeerSession;
-    private PeerSession subscriberPeerSession;
+    private PeerRelation publisherPeerRelation;
+    private PeerRelation subscriberPeerRelation;
 
     @BeforeEach
     void setUp() {
-        publisherPeerSession = new PeerSession("publisher-1");
-        subscriberPeerSession = new PeerSession("subscriber-1");
+        publisherPeerRelation = new PeerRelation("publisher-1");
+        subscriberPeerRelation = new PeerRelation("subscriber-1");
 
         lenient().when(publisherSession.getId()).thenReturn("publisher-1");
         lenient().when(subscriberSession.getId()).thenReturn("subscriber-1");
@@ -123,10 +123,10 @@ class MatchServiceTest {
     @DisplayName("피어 해제 - publisher에게 LEAVE 메시지 전송 및 재매칭")
     void unregisterPeer_ShouldNotifyPublisherAndRematch() {
         // given
-        subscriberPeerSession.setPublisher("publisher-1");
-        when(sessionService.remove("subscriber-1")).thenReturn(subscriberPeerSession);
+        subscriberPeerRelation.setPublisher("publisher-1");
+        when(sessionService.remove("subscriber-1")).thenReturn(subscriberPeerRelation);
         when(sessionService.getSession("publisher-1")).thenReturn(publisherSession);
-        when(sessionService.getPeerSession("publisher-1")).thenReturn(publisherPeerSession);
+        when(sessionService.getPeerRelation("publisher-1")).thenReturn(publisherPeerRelation);
         when(sessionService.isSessionValid(publisherSession)).thenReturn(true);
         when(findPeerService.findWaitingSubscriber(publisherSession)).thenReturn(null);
 
@@ -147,10 +147,10 @@ class MatchServiceTest {
     @DisplayName("피어 해제 - subscriber에게 LEAVE 메시지 전송 및 재매칭")
     void unregisterPeer_ShouldNotifySubscriberAndRematch() {
         // given
-        publisherPeerSession.setSubscriber("subscriber-1");
-        when(sessionService.remove("publisher-1")).thenReturn(publisherPeerSession);
+        publisherPeerRelation.setSubscriber("subscriber-1");
+        when(sessionService.remove("publisher-1")).thenReturn(publisherPeerRelation);
         when(sessionService.getSession("subscriber-1")).thenReturn(subscriberSession);
-        when(sessionService.getPeerSession("subscriber-1")).thenReturn(subscriberPeerSession);
+        when(sessionService.getPeerRelation("subscriber-1")).thenReturn(subscriberPeerRelation);
         when(sessionService.isSessionValid(subscriberSession)).thenReturn(true);
         when(findPeerService.findWaitingPublisher(subscriberSession)).thenReturn(null);
 
@@ -171,13 +171,13 @@ class MatchServiceTest {
     @DisplayName("피어 해제 - 대기 중인 새로운 피어가 있으면 즉시 재매칭")
     void unregisterPeer_ShouldRematchWithWaitingPeer() {
         // given
-        subscriberPeerSession.setPublisher("publisher-1");
+        subscriberPeerRelation.setPublisher("publisher-1");
         WebSocketSession newSubscriberSession = mock(WebSocketSession.class);
         lenient().when(newSubscriberSession.getId()).thenReturn("new-subscriber");
 
-        when(sessionService.remove("subscriber-1")).thenReturn(subscriberPeerSession);
+        when(sessionService.remove("subscriber-1")).thenReturn(subscriberPeerRelation);
         when(sessionService.getSession("publisher-1")).thenReturn(publisherSession);
-        when(sessionService.getPeerSession("publisher-1")).thenReturn(publisherPeerSession);
+        when(sessionService.getPeerRelation("publisher-1")).thenReturn(publisherPeerRelation);
         when(sessionService.isSessionValid(publisherSession)).thenReturn(true);
         when(sessionService.isSessionValid(newSubscriberSession)).thenReturn(true);
         when(sessionService.getSession("new-subscriber")).thenReturn(newSubscriberSession);

--- a/src/test/java/com/koa/sws/service/QueueTypeTest.java
+++ b/src/test/java/com/koa/sws/service/QueueTypeTest.java
@@ -1,6 +1,6 @@
-package com.koa.sws.model;
+package com.koa.sws.service;
 
-import com.koa.sws.service.RedisQueueService;
+import com.koa.sws.model.PeerSession;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/koa/sws/service/QueueTypeTest.java
+++ b/src/test/java/com/koa/sws/service/QueueTypeTest.java
@@ -1,6 +1,6 @@
 package com.koa.sws.service;
 
-import com.koa.sws.model.PeerSession;
+import com.koa.sws.model.PeerRelation;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -17,11 +17,11 @@ class QueueTypeTest {
     @Mock
     private RedisQueueService queueService;
 
-    private PeerSession peerSession;
+    private PeerRelation peerRelation;
 
     @BeforeEach
     void setUp() {
-        peerSession = new PeerSession("peer-1");
+        peerRelation = new PeerRelation("peer-1");
     }
 
     @Test
@@ -66,10 +66,10 @@ class QueueTypeTest {
     @DisplayName("PUBLISHER 타입 - getConnectedPeer는 subscriber를 반환")
     void publisher_ShouldReturnSubscriberAsConnectedPeer() {
         // given
-        peerSession.setSubscriber("subscriber-1");
+        peerRelation.setSubscriber("subscriber-1");
 
         // when
-        String connectedPeer = QueueType.PUBLISHER.getConnectedPeer(peerSession);
+        String connectedPeer = QueueType.PUBLISHER.getConnectedPeer(peerRelation);
 
         // then
         assertThat(connectedPeer).isEqualTo("subscriber-1");
@@ -117,10 +117,10 @@ class QueueTypeTest {
     @DisplayName("SUBSCRIBER 타입 - getConnectedPeer는 publisher를 반환")
     void subscriber_ShouldReturnPublisherAsConnectedPeer() {
         // given
-        peerSession.setPublisher("publisher-1");
+        peerRelation.setPublisher("publisher-1");
 
         // when
-        String connectedPeer = QueueType.SUBSCRIBER.getConnectedPeer(peerSession);
+        String connectedPeer = QueueType.SUBSCRIBER.getConnectedPeer(peerRelation);
 
         // then
         assertThat(connectedPeer).isEqualTo("publisher-1");

--- a/src/test/java/com/koa/sws/service/SignalMessageRelayServiceTest.java
+++ b/src/test/java/com/koa/sws/service/SignalMessageRelayServiceTest.java
@@ -1,0 +1,128 @@
+package com.koa.sws.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.koa.sws.model.MessageType;
+import com.koa.sws.model.SignalMessage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketSession;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class SignalMessageRelayServiceTest {
+
+    @Mock
+    private SessionService sessionService;
+
+    @Mock
+    private ObjectMapper objectMapper;
+
+    @Mock
+    private WebSocketSession session;
+
+    @InjectMocks
+    private SignalMessageRelayService relayService;
+
+    private SignalMessage testMessage;
+
+    @BeforeEach
+    void setUp() {
+        testMessage = new SignalMessage(MessageType.OFFER, "sender-1", "receiver-1", "offer-data");
+    }
+
+    @Test
+    @DisplayName("메시지 중계 성공 - 유효한 타겟 세션")
+    void relaySignalMessage_Success() throws Exception {
+        // given
+        when(sessionService.getSession("receiver-1")).thenReturn(session);
+        when(session.isOpen()).thenReturn(true);
+        when(objectMapper.writeValueAsString(testMessage)).thenReturn("{\"type\":\"OFFER\"}");
+
+        // when
+        relayService.relaySignalMessage(testMessage);
+
+        // then
+        verify(sessionService).getSession("receiver-1");
+        verify(session).sendMessage(any(TextMessage.class));
+    }
+
+    @Test
+    @DisplayName("메시지 중계 실패 - targetId가 null")
+    void relaySignalMessage_FailWhenTargetIdIsNull() throws Exception {
+        // given
+        testMessage.setTargetId(null);
+
+        // when
+        relayService.relaySignalMessage(testMessage);
+
+        // then
+        verify(sessionService, never()).getSession(anyString());
+        verify(session, never()).sendMessage(any());
+    }
+
+    @Test
+    @DisplayName("메시지 중계 실패 - 타겟 세션이 null")
+    void relaySignalMessage_FailWhenTargetSessionIsNull() throws Exception {
+        // given
+        when(sessionService.getSession("receiver-1")).thenReturn(null);
+
+        // when
+        relayService.relaySignalMessage(testMessage);
+
+        // then
+        verify(sessionService).getSession("receiver-1");
+        verify(session, never()).sendMessage(any());
+    }
+
+    @Test
+    @DisplayName("메시지 중계 실패 - 타겟 세션이 닫혀있음")
+    void relaySignalMessage_FailWhenTargetSessionIsClosed() throws Exception {
+        // given
+        when(sessionService.getSession("receiver-1")).thenReturn(session);
+        when(session.isOpen()).thenReturn(false);
+
+        // when
+        relayService.relaySignalMessage(testMessage);
+
+        // then
+        verify(sessionService).getSession("receiver-1");
+        verify(session, never()).sendMessage(any());
+    }
+
+    @Test
+    @DisplayName("메시지 전송 성공")
+    void sendMessage_Success() throws Exception {
+        // given
+        when(objectMapper.writeValueAsString(testMessage)).thenReturn("{\"type\":\"OFFER\"}");
+
+        // when
+        relayService.sendMessage(session, testMessage);
+
+        // then
+        verify(objectMapper).writeValueAsString(testMessage);
+        verify(session).sendMessage(any(TextMessage.class));
+    }
+
+    @Test
+    @DisplayName("메시지 전송 실패 - JSON 직렬화 오류")
+    void sendMessage_FailWhenJsonError() throws Exception {
+        // given
+        when(objectMapper.writeValueAsString(testMessage))
+                .thenThrow(new com.fasterxml.jackson.core.JsonProcessingException("JSON error"){});
+
+        // when
+        relayService.sendMessage(session, testMessage);
+
+        // then
+        verify(objectMapper).writeValueAsString(testMessage);
+        verify(session, never()).sendMessage(any());
+    }
+}

--- a/src/test/java/com/koa/sws/service/SignalMessageRelayServiceTest.java
+++ b/src/test/java/com/koa/sws/service/SignalMessageRelayServiceTest.java
@@ -43,7 +43,7 @@ class SignalMessageRelayServiceTest {
     void relaySignalMessage_Success() throws Exception {
         // given
         when(sessionService.getSession("receiver-1")).thenReturn(session);
-        when(session.isOpen()).thenReturn(true);
+        when(sessionService.isSessionValid(session)).thenReturn(true);
         when(objectMapper.writeValueAsString(testMessage)).thenReturn("{\"type\":\"OFFER\"}");
 
         // when
@@ -87,7 +87,7 @@ class SignalMessageRelayServiceTest {
     void relaySignalMessage_FailWhenTargetSessionIsClosed() throws Exception {
         // given
         when(sessionService.getSession("receiver-1")).thenReturn(session);
-        when(session.isOpen()).thenReturn(false);
+        when(sessionService.isSessionValid(session)).thenReturn(false);
 
         // when
         relayService.relaySignalMessage(testMessage);


### PR DESCRIPTION
## 🔀 Pull Request

### 🧩 Summary
- WebSocket 통신 리펙토링
- 세션 관리 및 메세지 전달 분리
- 실시간 접속자 수 API 추가

### 📋 Related Issue
<!-- e.g. Fixes #123 / Closes #123 -->

### 💡 Changes

### 🧪 Test Plan
<!-- Describe how you tested your changes. -->

### ✅ Checklist
- [ ] My code follows the project style guide
- [ ] I added necessary tests or updated existing ones
- [ ] I updated relevant documentation
- [ ] No console errors or warnings

### 📸 Screenshots (optional)
