### PR TITLE
refactor: 시그널링 서비스 분리 및 peer 상태 Redis 위임

### DIFF
--- a/src/main/java/com/koa/sws/handler/SignalingWebSocketHandler.java
+++ b/src/main/java/com/koa/sws/handler/SignalingWebSocketHandler.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.koa.sws.model.MessageType;
 import com.koa.sws.model.SignalMessage;
 import com.koa.sws.service.MatchService;
-import com.koa.sws.service.SessionService;
+import com.koa.sws.service.SignalRelayService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -19,56 +19,39 @@ import org.springframework.web.socket.handler.TextWebSocketHandler;
 public class SignalingWebSocketHandler extends TextWebSocketHandler {
 
     private final ObjectMapper objectMapper;
-    private final SessionService sessionService;
     private final MatchService matchService;
+    private final SignalRelayService relayService;
 
     @Override
     public void afterConnectionEstablished(WebSocketSession session) {
-        String peerId = sessionService.register(session);
-        log.info("⭐ CONNECTED: peerId={}", peerId);
-
+        log.info("⭐ CONNECTED: peerId={}", session.getId());
         matchService.registerPeer(session);
     }
 
     @Override
-    protected void handleTextMessage(WebSocketSession session, TextMessage message) throws Exception {
+    protected void handleTextMessage(WebSocketSession session, TextMessage message) {
         try {
             SignalMessage signalMessage = objectMapper.readValue(message.getPayload(), SignalMessage.class);
-
-            if (!session.isOpen()) {
-                log.warn("Received message from unopen session: {}", session.getId());
-                return;
-            }
-
             signalMessage.setMyId(session.getId());
 
             switch (signalMessage.getType()) {
-                case OFFER:
-                case ANSWER:
-                case ICE:
-                    matchService.relaySignalMessage(signalMessage);
-                    break;
-                case LEAVE:
-                    //matchService.unregisterPeer(session.getId());
-                    break;
-                case JOIN:
-                    break;
-                default:
+                case OFFER, ANSWER, ICE -> relayService.relay(signalMessage);
+                default -> {
                     log.warn("Unknown message type: {}", signalMessage.getType());
-                    matchService.sendMessage(session, new SignalMessage(MessageType.ERROR, session.getId(), null, "Unknown message type"));
+                    relayService.sendDirect(session, new SignalMessage(MessageType.ERROR, session.getId(), null, "Unknown message type"));
+                }
             }
         } catch (Exception e) {
             log.error("Error handling message", e);
-
-            if (session.isOpen())
-                matchService.sendMessage(session, new SignalMessage(MessageType.ERROR, session.getId(), null, "Failed message"));
+            if (session.isOpen()) {
+                relayService.sendDirect(session, new SignalMessage(MessageType.ERROR, session.getId(), null, "Failed message"));
+            }
         }
-
     }
 
     @Override
     public void afterConnectionClosed(WebSocketSession session, CloseStatus status) {
-        matchService.unregisterPeer(session.getId());
         log.debug("🔴 DISCONNECTED: peerId={} status={}", session.getId(), status);
+        matchService.unregisterPeer(session.getId());
     }
 }

--- a/src/main/java/com/koa/sws/handler/SignalingWebSocketHandler.java
+++ b/src/main/java/com/koa/sws/handler/SignalingWebSocketHandler.java
@@ -69,6 +69,6 @@ public class SignalingWebSocketHandler extends TextWebSocketHandler {
     @Override
     public void afterConnectionClosed(WebSocketSession session, CloseStatus status) {
         matchService.unregisterPeer(session.getId());
-        log.info("🔴 DISCONNECTED: peerId={} status={}", session.getId(), status);
+        log.debug("🔴 DISCONNECTED: peerId={} status={}", session.getId(), status);
     }
 }

--- a/src/main/java/com/koa/sws/service/MatchService.java
+++ b/src/main/java/com/koa/sws/service/MatchService.java
@@ -29,11 +29,11 @@ public class MatchService {
     public void registerPeer(WebSocketSession session) {
 
         // 1. register as publisher
-        log.info("🔗 Register as Publisher");
+        log.debug("🔗 Register as Publisher");
         registerAsPublisher(session);
 
         // 2. register as subscriber
-        log.info("🔗 Register as Subscriber");
+        log.debug("🔗 Register as Subscriber");
         registerAsSubscriber(session);
     }
 

--- a/src/main/java/com/koa/sws/service/MatchService.java
+++ b/src/main/java/com/koa/sws/service/MatchService.java
@@ -1,16 +1,12 @@
 package com.koa.sws.service;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.koa.sws.model.MessageType;
 import com.koa.sws.model.PeerSession;
 import com.koa.sws.model.SignalMessage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-import org.springframework.web.socket.TextMessage;
 import org.springframework.web.socket.WebSocketSession;
-
-import java.io.IOException;
 
 @Slf4j
 @Service
@@ -18,42 +14,36 @@ import java.io.IOException;
 public class MatchService {
 
     private final SessionService sessionService;
+    private final RedisPeerService redisPeerService;
     private final RedisQueueService queueService;
-    private final ObjectMapper objectMapper;
+    private final SignalRelayService relayService;
 
     /**
      * 사용자 등록
-     * 1. as publisher
-     * 2. as subscriber
      */
     public void registerPeer(WebSocketSession session) {
+        sessionService.register(session);
 
-        // 1. register as publisher
         log.debug("🔗 Register as Publisher");
         registerAsPublisher(session);
 
-        // 2. register as subscriber
         log.debug("🔗 Register as Subscriber");
         registerAsSubscriber(session);
     }
 
     public void registerAsPublisher(WebSocketSession session) {
-
         String myId = session.getId();
-
-        WebSocketSession subscriberSession = getWaitingSubscriber(session);
-        if (subscriberSession == null) {
+        String subscriberId = getWaitingSubscriberId(myId);
+        if (subscriberId == null) {
             queueService.addToPublishQueue(myId);
         } else {
-            match(myId, subscriberSession.getId());
+            match(myId, subscriberId);
         }
     }
 
     public void registerAsSubscriber(WebSocketSession session) {
-
         String myId = session.getId();
-
-        String publisherId = getWaitingPublisher(session);
+        String publisherId = getWaitingPublisherId(myId);
         if (publisherId == null) {
             queueService.addToSubscribeQueue(myId);
         } else {
@@ -80,50 +70,25 @@ public class MatchService {
         // 3. Remove mine in queue -> X (when pop, check the session avaible)
     }
 
-    /**
-     * 메세지 중계 (OFFER, ANSWER, ICE)
-     */
-    public void relaySignalMessage(SignalMessage message) {
+    // --
 
-        String fromId = message.getMyId();     // 메시지 보낸 사람
-        String toId = message.getTargetId();   // 전달해야 할 상대방
-
-        if (toId == null) {
-            log.warn("relay failed: targetId is null. fromId={}", fromId);
-            return;
-        }
-
-        WebSocketSession targetSession = sessionService.getSession(toId);
-        if (!isSessionValid(targetSession)) {
-            log.warn("relay failed: target session invalid. targetId={}", toId);
-            return;
-        }
-
-        // 그대로 상대에게 메시지 전달
-        sendMessage(targetSession, message);
-        log.info("🔁 Relayed {} from {} → {}", message.getType(), fromId, toId);
-    }
-
-    //
     private void unregisterMyPublisher(String publisherId, String myId) {
         if (publisherId == null) {
             log.debug("No connected publisher for {}", myId);
             return;
         }
 
-        WebSocketSession publisherSession = sessionService.getSession(publisherId);
-        PeerSession publisherPeerSession = sessionService.getPeerSession(publisherId);
-        if (!isSessionValid(publisherSession) || publisherPeerSession == null) {
+        if (!redisPeerService.isPresent(publisherId) || redisPeerService.getPeerSession(publisherId) == null) {
             log.warn("Publisher session not found: {}", publisherId);
             return;
         }
 
-        sendMessage(publisherSession, new SignalMessage(MessageType.LEAVE, publisherId, myId, "Subscriber has left session"));
-        sessionService.updateSubscriber(publisherId, null);
+        relayService.sendToPeer(publisherId, new SignalMessage(MessageType.LEAVE, publisherId, myId, "Subscriber has left session"));
+        redisPeerService.updateSubscriber(publisherId, null);
 
-        WebSocketSession subscriberSession = getWaitingSubscriber(publisherSession);
-        if (subscriberSession != null) {
-            match(publisherId, subscriberSession.getId());
+        String newSubscriberId = getWaitingSubscriberId(publisherId);
+        if (newSubscriberId != null) {
+            match(publisherId, newSubscriberId);
         } else {
             queueService.addToPublishQueue(publisherId);
         }
@@ -135,138 +100,116 @@ public class MatchService {
             return;
         }
 
-        WebSocketSession subscriberSession = sessionService.getSession(subscriberId);
-        PeerSession subscriberPeerSession = sessionService.getPeerSession(subscriberId);
-
-        if (!isSessionValid(subscriberSession) || subscriberPeerSession == null) {
+        if (!redisPeerService.isPresent(subscriberId) || redisPeerService.getPeerSession(subscriberId) == null) {
             log.warn("Subscriber session not found: {}", subscriberId);
             return;
         }
 
-        sendMessage(subscriberSession, new SignalMessage(MessageType.LEAVE, subscriberId, myId, "Subscriber has left session"));
-        sessionService.updatePublisher(subscriberId, null);
+        relayService.sendToPeer(subscriberId, new SignalMessage(MessageType.LEAVE, subscriberId, myId, "Subscriber has left session"));
+        redisPeerService.updatePublisher(subscriberId, null);
 
-        String publisherId = getWaitingPublisher(subscriberSession);
-        if (publisherId != null) {
-            match(publisherId, subscriberId);
+        String newPublisherId = getWaitingPublisherId(subscriberId);
+        if (newPublisherId != null) {
+            match(newPublisherId, subscriberId);
         } else {
             queueService.addToSubscribeQueue(subscriberId);
             log.info("-> after disconnected add subscriber queue: {}", myId);
         }
     }
 
-    private WebSocketSession getWaitingSubscriber(WebSocketSession session) {
+    private String getWaitingSubscriberId(String peerId) {
+        PeerSession peerSession = redisPeerService.getPeerSession(peerId);
 
-        // 1. get my peer session
-        PeerSession peerSession = sessionService.getPeerSession(session.getId());
+        String foundSubscriberId = null;
+        String subscriberToRestore = null;
+        boolean shouldRestoreMine = false;
 
-        String subscriberId = null;
-        WebSocketSession subscriberSession = null;
+        while (queueService.getSubscribeQueueSize() > 0 && foundSubscriberId == null) {
+            String candidateId = queueService.popFromSubscribeQueue();
+            if (candidateId == null) break;
 
-        boolean needRestoreSubscriber = false;
-        boolean needResotoreMine = false;
-
-        // 2. check subscribe Queue
-        while (queueService.getSubscribeQueueSize() > 0 && !isSessionValid(subscriberSession)) {
-            subscriberId = queueService.popFromSubscribeQueue();
-            subscriberSession = sessionService.getSession(subscriberId);
-
-            // condition1) subscriber cannot be my subsciber as publisher.
-            if (peerSession.getPublisher() != null && !isPeerAvailable(subscriberId, peerSession.getPublisher())) {
-                log.warn("peer is not availble : {} <-> {}" , subscriberId, peerSession.getPublisher());
-                subscriberId = null;
-                needRestoreSubscriber = true;
+            if (!redisPeerService.isPresent(candidateId)) {
+                continue;
             }
 
-            // condition2) subscriber cannot be myself.
-            if (subscriberId != null && subscriberId.equals(session.getId())) {
-                subscriberId = null;
-                needResotoreMine = true;
+            if (peerSession != null && peerSession.getPublisher() != null
+                    && !isPeerAvailable(candidateId, peerSession.getPublisher())) {
+                log.warn("peer is not available : {} <-> {}", candidateId, peerSession.getPublisher());
+                subscriberToRestore = candidateId;
+                continue;
             }
 
+            if (candidateId.equals(peerId)) {
+                shouldRestoreMine = true;
+                continue;
+            }
+
+            foundSubscriberId = candidateId;
         }
 
-        if (needRestoreSubscriber) queueService.addToSubscribeQueue(peerSession.getPublishTo());
-        if (needResotoreMine) queueService.addToSubscribeQueue(session.getId());
+        if (subscriberToRestore != null) queueService.addToSubscribeQueue(subscriberToRestore);
+        if (shouldRestoreMine) queueService.addToSubscribeQueue(peerId);
 
-        if (subscriberId == null || subscriberSession == null) {
+        if (foundSubscriberId == null) {
             log.info("❌ No waiting subscriber in subscribe queue");
-            return null;
         }
-        return subscriberSession;
+        return foundSubscriberId;
     }
 
-    private String getWaitingPublisher(WebSocketSession session) {
+    private String getWaitingPublisherId(String peerId) {
+        PeerSession peerSession = redisPeerService.getPeerSession(peerId);
 
-        PeerSession peerSession = sessionService.getPeerSession(session.getId());
+        String foundPublisherId = null;
+        String publisherToRestore = null;
+        boolean shouldRestoreMine = false;
 
-        String publisherId = null;
-        WebSocketSession publisherSession = null;
+        while (queueService.getPublishQueueSize() > 0 && foundPublisherId == null) {
+            String candidateId = queueService.popFromPublishQueue();
+            if (candidateId == null) break;
 
-        boolean needRestorePublisher = false;
-        boolean needRestoreMine = false;
-
-        while (queueService.getPublishQueueSize() > 0 && !isSessionValid(publisherSession)) {
-            publisherId = queueService.popFromPublishQueue();
-            publisherSession = sessionService.getSession(publisherId);
-
-            if (peerSession.getSubscriber() != null && !isPeerAvailable(publisherId, peerSession.getSubscriber())) {
-                log.warn("peer is not availble : {} <-> {}" , publisherId, peerSession.getSubscriber());
-                publisherId = null;
-                needRestorePublisher = true;
+            if (!redisPeerService.isPresent(candidateId)) {
+                continue;
             }
 
-            if (publisherId != null && publisherId.equals(session.getId())) {
-                publisherId = null;
-                needRestoreMine = true;
+            if (peerSession != null && peerSession.getSubscriber() != null
+                    && !isPeerAvailable(candidateId, peerSession.getSubscriber())) {
+                log.warn("peer is not available : {} <-> {}", candidateId, peerSession.getSubscriber());
+                publisherToRestore = candidateId;
+                continue;
             }
+
+            if (candidateId.equals(peerId)) {
+                shouldRestoreMine = true;
+                continue;
+            }
+
+            foundPublisherId = candidateId;
         }
 
-        if (needRestorePublisher) queueService.addToPublishQueue(peerSession.getSubscriber());
-        if (needRestoreMine) queueService.addToPublishQueue(session.getId());
+        if (publisherToRestore != null) queueService.addToPublishQueue(publisherToRestore);
+        if (shouldRestoreMine) queueService.addToPublishQueue(peerId);
 
-        if (publisherId == null || publisherSession == null) {
+        if (foundPublisherId == null) {
             log.info("❌ No publisher in publish queue");
-            return null;
         }
-
-        return publisherId;
+        return foundPublisherId;
     }
 
     private void match(String publisherId, String subscriberId) {
-
-        // 1. find Session
-        WebSocketSession publisherSession = sessionService.getSession(publisherId);
-        WebSocketSession subscriberSession = sessionService.getSession(subscriberId);
-        if (!isSessionValid(subscriberSession) || !isSessionValid(publisherSession)) {
+        if (!redisPeerService.isPresent(publisherId) || !redisPeerService.isPresent(subscriberId)) {
             log.info("Session not active: {} <-> {}", subscriberId, publisherId);
             return;
         }
 
-        // 2. send Websocket Message
-        sendMessage(publisherSession, new SignalMessage(MessageType.PUBLISH, publisherId, subscriberId));
-        sendMessage(subscriberSession, new SignalMessage(MessageType.SUBSCRIBE, subscriberId, publisherId));
+        relayService.sendToPeer(publisherId, new SignalMessage(MessageType.PUBLISH, publisherId, subscriberId));
+        relayService.sendToPeer(subscriberId, new SignalMessage(MessageType.SUBSCRIBE, subscriberId, publisherId));
 
-        // 3. session info update
-        sessionService.updateSubscriber(publisherId, subscriberId);
-        sessionService.updatePublisher(subscriberId, publisherId);
+        redisPeerService.updateSubscriber(publisherId, subscriberId);
+        redisPeerService.updatePublisher(subscriberId, publisherId);
         log.info("📤 Sent MATCH message) publisher: {}, subscriber: {}", publisherId, subscriberId);
-    }
-
-    public void sendMessage(WebSocketSession session, SignalMessage message) {
-        try {
-            String json = objectMapper.writeValueAsString(message);
-            session.sendMessage(new TextMessage(json));
-        } catch (IOException e) {
-            log.error("Failed to send message type {}: {}", message.getType(), e.getMessage());
-        }
     }
 
     private boolean isPeerAvailable(String targetPeerId, String myPeerId) {
         return targetPeerId != null && myPeerId != null && !targetPeerId.equals(myPeerId);
-    }
-
-    private boolean isSessionValid(WebSocketSession session) {
-        return session != null && session.isOpen();
     }
 }

--- a/src/main/java/com/koa/sws/service/RedisPeerService.java
+++ b/src/main/java/com/koa/sws/service/RedisPeerService.java
@@ -1,0 +1,74 @@
+package com.koa.sws.service;
+
+import com.koa.sws.model.PeerSession;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+
+/**
+ * peer의 존재 여부와 publisher/subscriber 관계를 공유
+ *
+ * Redis key 구조:
+ *   sws:peer:{peerId}            → presence ("1"), TTL 24h
+ *   sws:peer:{peerId}:publisher  → publisherId
+ *   sws:peer:{peerId}:subscriber → subscriberId
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RedisPeerService {
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    private static final String PEER_PREFIX = "sws:peer:";
+    private static final String PUBLISHER_SUFFIX = ":publisher";
+    private static final String SUBSCRIBER_SUFFIX = ":subscriber";
+    private static final Duration SESSION_TTL = Duration.ofHours(24);
+
+    public void register(String peerId) {
+        redisTemplate.opsForValue().set(PEER_PREFIX + peerId, "1", SESSION_TTL);
+        log.debug("Registered peer presence in Redis: {}", peerId);
+    }
+
+    public void remove(String peerId) {
+        redisTemplate.delete(PEER_PREFIX + peerId);
+        redisTemplate.delete(PEER_PREFIX + peerId + PUBLISHER_SUFFIX);
+        redisTemplate.delete(PEER_PREFIX + peerId + SUBSCRIBER_SUFFIX);
+        log.debug("Removed peer from Redis: {}", peerId);
+    }
+
+    public void updatePublisher(String peerId, String publisherId) {
+        String key = PEER_PREFIX + peerId + PUBLISHER_SUFFIX;
+        if (publisherId == null) {
+            redisTemplate.delete(key);
+        } else {
+            redisTemplate.opsForValue().set(key, publisherId, SESSION_TTL);
+        }
+    }
+
+    public void updateSubscriber(String peerId, String subscriberId) {
+        String key = PEER_PREFIX + peerId + SUBSCRIBER_SUFFIX;
+        if (subscriberId == null) {
+            redisTemplate.delete(key);
+        } else {
+            redisTemplate.opsForValue().set(key, subscriberId, SESSION_TTL);
+        }
+    }
+
+    public PeerSession getPeerSession(String peerId) {
+        if (!isPresent(peerId)) return null;
+
+        PeerSession peerSession = new PeerSession(peerId);
+        peerSession.setPublisher(redisTemplate.opsForValue().get(PEER_PREFIX + peerId + PUBLISHER_SUFFIX));
+        peerSession.setSubscriber(redisTemplate.opsForValue().get(PEER_PREFIX + peerId + SUBSCRIBER_SUFFIX));
+        return peerSession;
+    }
+
+    public boolean isPresent(String peerId) {
+        if (peerId == null) return false;
+        return Boolean.TRUE.equals(redisTemplate.hasKey(PEER_PREFIX + peerId));
+    }
+}

--- a/src/main/java/com/koa/sws/service/RedisQueueService.java
+++ b/src/main/java/com/koa/sws/service/RedisQueueService.java
@@ -17,26 +17,26 @@ public class RedisQueueService {
     private static final String SUBSCRIBE_QUEUE = "sws:subscribeQueue";
 
     public void addToPublishQueue(String peerId) {
-        log.info("🔫 ADD Publisher queue: {}", peerId);
+        log.debug("🔫 ADD Publisher queue: {}", peerId);
         enqueue(getPublishQueueName(), peerId);
     }
 
     public void addToSubscribeQueue(String peerId) {
-        log.info("🔫 ADD Subscriber queue: {}", peerId);
+        log.debug("🔫 ADD Subscriber queue: {}", peerId);
         enqueue(getSubscribeQueueName(), peerId);
     }
 
     @DistributedLock(key = "'publishQueue'")
     public String popFromPublishQueue() {
         String peerId = dequeue(getPublishQueueName());
-        log.info("🦷 POP Publisher queue: {}", peerId);
+        log.debug("🦷 POP Publisher queue: {}", peerId);
         return peerId;
     }
 
     @DistributedLock(key = "'subscribeQueue'")
     public String popFromSubscribeQueue() {
         String peerId = dequeue(getSubscribeQueueName());
-        log.info("🦷 POP Subscriber queue: {}", peerId);
+        log.debug("🦷 POP Subscriber queue: {}", peerId);
         return peerId;
     }
 

--- a/src/main/java/com/koa/sws/service/SessionService.java
+++ b/src/main/java/com/koa/sws/service/SessionService.java
@@ -1,6 +1,7 @@
 package com.koa.sws.service;
 
 import com.koa.sws.model.PeerSession;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.web.socket.WebSocketSession;
@@ -11,32 +12,32 @@ import java.util.concurrent.ConcurrentHashMap;
 
 @Slf4j
 @Service
+@RequiredArgsConstructor
 public class SessionService {
 
     private final Map<String, WebSocketSession> websocketSessions = new ConcurrentHashMap<>();
-    private final Map<String, PeerSession> peerSessions = new ConcurrentHashMap<>();
+    private final RedisPeerService redisPeerService;
 
     public String register(WebSocketSession session) {
-        websocketSessions.put(session.getId(), session);
-        peerSessions.put(session.getId(), new PeerSession(session.getId()));
-        return session.getId();
+        String peerId = session.getId();
+        websocketSessions.put(peerId, session);
+        redisPeerService.register(peerId);
+        return peerId;
     }
 
     public PeerSession remove(String sessionId) {
-        PeerSession peer = peerSessions.remove(sessionId);
         websocketSessions.remove(sessionId);
-
-        return peer;
+        PeerSession peerSession = redisPeerService.getPeerSession(sessionId);
+        redisPeerService.remove(sessionId);
+        return peerSession;
     }
 
     public void updatePublisher(String peerId, String publisherId) {
-        PeerSession peerSession = peerSessions.get(peerId);
-        peerSession.setPublisher(publisherId);
+        redisPeerService.updatePublisher(peerId, publisherId);
     }
 
     public void updateSubscriber(String peerId, String subscriberId) {
-        PeerSession peerSession = peerSessions.get(peerId);
-        peerSession.setSubscriber(subscriberId);
+        redisPeerService.updateSubscriber(peerId, subscriberId);
     }
 
     public WebSocketSession getSession(String peerId) {
@@ -46,7 +47,11 @@ public class SessionService {
 
     public PeerSession getPeerSession(String peerId) {
         if (peerId == null) return null;
-        return peerSessions.get(peerId);
+        return redisPeerService.getPeerSession(peerId);
+    }
+
+    public boolean isPeerPresent(String peerId) {
+        return redisPeerService.isPresent(peerId);
     }
 
     public Collection<WebSocketSession> getAllSessions() {

--- a/src/main/java/com/koa/sws/service/SignalRelayService.java
+++ b/src/main/java/com/koa/sws/service/SignalRelayService.java
@@ -1,0 +1,62 @@
+package com.koa.sws.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.koa.sws.model.SignalMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketSession;
+
+import java.io.IOException;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SignalRelayService {
+
+    private final SessionService sessionService;
+    private final RedisPeerService redisPeerService;
+    private final ObjectMapper objectMapper;
+
+    /**
+     * 메시지 중계 (OFFER, ANSWER, ICE)
+     */
+    public void relay(SignalMessage message) {
+        String fromId = message.getMyId();
+        String toId = message.getTargetId();
+
+        if (toId == null) {
+            log.warn("relay failed: targetId is null. fromId={}", fromId);
+            return;
+        }
+
+        if (!redisPeerService.isPresent(toId)) {
+            log.warn("relay failed: target not present. targetId={}", toId);
+            return;
+        }
+
+        sendToPeer(toId, message);
+        log.info("🔁 Relayed {} from {} → {}", message.getType(), fromId, toId);
+    }
+
+    public void sendToPeer(String peerId, SignalMessage message) {
+        WebSocketSession session = sessionService.getSession(peerId);
+        if (session != null && session.isOpen()) {
+            sendDirect(session, message);
+        } else {
+            log.warn("sendToPeer failed: session not found or closed. peerId={}", peerId);
+        }
+    }
+
+    /**
+     * 로컬 WebSocket 세션에 직접 전송
+     */
+    public void sendDirect(WebSocketSession session, SignalMessage message) {
+        try {
+            session.sendMessage(new TextMessage(objectMapper.writeValueAsString(message)));
+        } catch (IOException e) {
+            log.error("Failed to send message type {}: {}", message.getType(), e.getMessage());
+        }
+    }
+}

--- a/src/test/java/com/koa/sws/service/RedisQueueServiceTest.java
+++ b/src/test/java/com/koa/sws/service/RedisQueueServiceTest.java
@@ -31,7 +31,7 @@ class RedisQueueServiceTest {
         // 큐 초기화
         redissonClient.getKeys().delete("sws:publishQueue");
 
-        int TOTAL = 50;
+        int TOTAL = 1000;
         for (int i = 1; i <= TOTAL; i++) {
             queueService.addToPublishQueue("USER-" + i);
         }


### PR DESCRIPTION
## 🔀 Pull Request

### 🧩 Summary
  - SignalingWebSocketHandler - SessionService 의존 제거, switch arrow case 정리                                                    
  - MatchService - WebSocketSession → peerId 기반으로 전환, relaySignalMessage/sendMessage 제거                                
  - SessionService - 내부 Map 제거, RedisPeerService로 위임          
  - RedisPeerService - peer 존재 여부 및 publisher/subscriber 관계를 Redis에 저장                                        
  - SignalRelayService - 메시지 전송 책임 분리

### 📋 Related Issue
<!-- e.g. Fixes #123 / Closes #123 -->

### 💡 Changes
- [ ] Added ...
- [ ] Fixed ...
- [ ] Refactored ...
- [ ] Updated documentation

### 🧪 Test Plan
<!-- Describe how you tested your changes. -->

### ✅ Checklist
- [ ] My code follows the project style guide
- [ ] I added necessary tests or updated existing ones
- [ ] I updated relevant documentation
- [ ] No console errors or warnings

### 📸 Screenshots (optional)
