### PR TITLE
fix: Redis 동시성 이슈로 인한 ghost 데이터 문제 해결 (Lua atomic 적용)

### DIFF
--- a/src/main/java/com/koa/sws/handler/SignalingWebSocketHandler.java
+++ b/src/main/java/com/koa/sws/handler/SignalingWebSocketHandler.java
@@ -105,8 +105,12 @@ public class SignalingWebSocketHandler extends TextWebSocketHandler {
 
     @Override
     public void afterConnectionClosed(WebSocketSession session, CloseStatus status) {
-        matchService.unregisterPeer(session.getId());
-        log.info("WebSocket connection closed - peerId: {}, status: {}, reason: {}",
-                session.getId(), status.getCode(), status.getReason());
+        try {
+            matchService.unregisterPeer(session.getId());
+        } finally {
+            log.info("WebSocket connection closed - peerId: {}, status: {}, reason: {}",
+                    session.getId(), status.getCode(), status.getReason());
+        }
+
     }
 }

--- a/src/main/java/com/koa/sws/service/MatchService.java
+++ b/src/main/java/com/koa/sws/service/MatchService.java
@@ -77,6 +77,11 @@ public class MatchService {
         }
 
         WebSocketSession publisherSession = sessionService.getSession(publisherId);
+        if (publisherSession == null) {
+            log.warn("Publisher session already removed (concurrent disconnect): {}", publisherId);
+            // TODO: 매칭 취소 후 처리
+            return;
+        }
         relayService.sendMessage(publisherSession, new SignalMessage(MessageType.LEAVE, publisherId, myId, "Subscriber has left session"));
         sessionService.updateSubscriber(publisherId, null);
 
@@ -100,6 +105,11 @@ public class MatchService {
         }
 
         WebSocketSession subscriberSession = sessionService.getSession(subscriberId);
+        if (subscriberSession == null) {
+            log.warn("Subscriber session already removed (concurrent disconnect): {}", subscriberId);
+            // TODO: 매칭 취소 후 처리
+            return;
+        }
         relayService.sendMessage(subscriberSession, new SignalMessage(MessageType.LEAVE, subscriberId, myId, "Publisher has left session"));
         sessionService.updatePublisher(subscriberId, null);
 
@@ -120,6 +130,10 @@ public class MatchService {
 
         WebSocketSession publisherSession = sessionService.getSession(publisherId);
         WebSocketSession subscriberSession = sessionService.getSession(subscriberId);
+        if (publisherSession == null || subscriberSession == null) {
+            log.warn("Session already removed during match (concurrent disconnect): publisher={}, subscriber={}", publisherId, subscriberId);
+            return;
+        }
 
         relayService.sendMessage(publisherSession, new SignalMessage(MessageType.PUBLISH, publisherId, subscriberId));
         relayService.sendMessage(subscriberSession, new SignalMessage(MessageType.SUBSCRIBE, subscriberId, publisherId));

--- a/src/main/java/com/koa/sws/service/RedisPeerService.java
+++ b/src/main/java/com/koa/sws/service/RedisPeerService.java
@@ -4,8 +4,11 @@ import com.koa.sws.constant.RedisKeyConstants;
 import com.koa.sws.model.PeerRelation;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.script.RedisScript;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 /**
  * peer의 존재 여부와 publisher/subscriber 관계를 Redis에서 관리
@@ -26,15 +29,40 @@ public class RedisPeerService {
     private static final String PUBLISHER_SUFFIX = RedisKeyConstants.PUBLISHER_SUFFIX;
     private static final String SUBSCRIBER_SUFFIX = RedisKeyConstants.SUBSCRIBER_SUFFIX;
 
+    // peer 키 3개 삭제 + 두 큐에서 제거 + 파트너의 stale 참조 삭제를 원자적으로 실행
+    // KEYS[1]=peer, KEYS[2]=peer:publisher, KEYS[3]=peer:subscriber, KEYS[4]=publishQueue, KEYS[5]=subscribeQueue
+    // ARGV[1]=peerId, ARGV[2]=publisher의 :subscriber 키(없으면 ""), ARGV[3]=subscriber의 :publisher 키(없으면 "")
+    private static final RedisScript<Long> REMOVE_PEER_AND_DEQUEUE = RedisScript.of(
+            """
+            redis.call('DEL', KEYS[1], KEYS[2], KEYS[3])
+            redis.call('ZREM', KEYS[4], ARGV[1])
+            redis.call('ZREM', KEYS[5], ARGV[1])
+            if ARGV[2] ~= '' then redis.call('DEL', ARGV[2]) end
+            if ARGV[3] ~= '' then redis.call('DEL', ARGV[3]) end
+            return 1
+            """,
+            Long.class
+    );
+
     public void register(String peerId) {
         redisTemplate.opsForValue().set(PEER_PREFIX + peerId, "1", RedisKeyConstants.PEER_SESSION_TTL);
         log.debug("Registered peer in Redis: {}", peerId);
     }
 
-    public void remove(String peerId) {
-        redisTemplate.delete(PEER_PREFIX + peerId);
-        redisTemplate.delete(PEER_PREFIX + peerId + PUBLISHER_SUFFIX);
-        redisTemplate.delete(PEER_PREFIX + peerId + SUBSCRIBER_SUFFIX);
+    public void remove(String peerId, String publisherId, String subscriberId) {
+        redisTemplate.execute(
+                REMOVE_PEER_AND_DEQUEUE,
+                List.of(
+                        PEER_PREFIX + peerId,
+                        PEER_PREFIX + peerId + PUBLISHER_SUFFIX,
+                        PEER_PREFIX + peerId + SUBSCRIBER_SUFFIX,
+                        RedisKeyConstants.PUBLISH_QUEUE,
+                        RedisKeyConstants.SUBSCRIBE_QUEUE
+                ),
+                peerId,
+                publisherId != null ? PEER_PREFIX + publisherId + SUBSCRIBER_SUFFIX : "",
+                subscriberId != null ? PEER_PREFIX + subscriberId + PUBLISHER_SUFFIX : ""
+        );
         log.debug("Removed peer from Redis: {}", peerId);
     }
 

--- a/src/main/java/com/koa/sws/service/RedisQueueService.java
+++ b/src/main/java/com/koa/sws/service/RedisQueueService.java
@@ -3,9 +3,12 @@ package com.koa.sws.service;
 import com.koa.sws.constant.RedisKeyConstants;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.script.RedisScript;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Slf4j
 @Service
@@ -13,6 +16,19 @@ import org.springframework.stereotype.Service;
 public class RedisQueueService {
 
     private final RedisTemplate<String, String> redisTemplate;
+
+    // peer 키가 존재할 때만 큐에 추가 — EXISTS + ZADD를 원자적으로 실행해 ghost 항목 방지
+    // KEYS[1]=sws:peer:{peerId}, KEYS[2]=queue, ARGV[1]=score, ARGV[2]=peerId
+    private static final RedisScript<Long> ENQUEUE_IF_PEER_EXISTS = RedisScript.of(
+            """
+            if redis.call('EXISTS', KEYS[1]) == 1 then
+                redis.call('ZADD', KEYS[2], ARGV[1], ARGV[2])
+                return 1
+            end
+            return 0
+            """,
+            Long.class
+    );
 
     public void addToPublishQueue(String peerId) {
         log.info("Adding to publisher queue - peerId: {}", peerId);
@@ -55,7 +71,16 @@ public class RedisQueueService {
     }
 
     private void enqueue(String queue, String peerId) {
-        redisTemplate.opsForZSet().add(queue, peerId, System.currentTimeMillis());
+        String peerKey = RedisKeyConstants.PEER_PREFIX + peerId;
+        Long result = redisTemplate.execute(
+                ENQUEUE_IF_PEER_EXISTS,
+                List.of(peerKey, queue),
+                String.valueOf(System.currentTimeMillis()),
+                peerId
+        );
+        if (result == null || result == 0L) {
+            log.warn("Skipped enqueue - peer key not found: {}", peerId);
+        }
     }
 
     private String pop(String queue) {

--- a/src/main/java/com/koa/sws/service/SessionService.java
+++ b/src/main/java/com/koa/sws/service/SessionService.java
@@ -33,7 +33,9 @@ public class SessionService {
     public PeerRelation remove(String sessionId) {
         websocketSessions.remove(sessionId);
         PeerRelation relation = redisPeerService.getPeerRelation(sessionId);
-        redisPeerService.remove(sessionId);
+        String publisherId = relation != null ? relation.getPublisher() : null;
+        String subscriberId = relation != null ? relation.getSubscriber() : null;
+        redisPeerService.remove(sessionId, publisherId, subscriberId);
         return relation;
     }
 

--- a/src/main/java/com/koa/sws/service/SignalMessageRelayService.java
+++ b/src/main/java/com/koa/sws/service/SignalMessageRelayService.java
@@ -47,6 +47,8 @@ public class SignalMessageRelayService {
         try {
             String json = objectMapper.writeValueAsString(message);
             session.sendMessage(new TextMessage(json));
+        } catch (IllegalStateException e) {
+            log.warn("Session closed before message sent - type: {}, sessionId: {}", message.getType(), session.getId());
         } catch (IOException e) {
             log.error("Failed to send message - type: {}, error: {}", message.getType(), e.getMessage());
         }

--- a/src/test/java/com/koa/sws/service/MatchServiceTest.java
+++ b/src/test/java/com/koa/sws/service/MatchServiceTest.java
@@ -22,6 +22,9 @@ class MatchServiceTest {
     private SessionService sessionService;
 
     @Mock
+    private RedisPeerService redisPeerService;
+
+    @Mock
     private RedisQueueService queueService;
 
     @Mock
@@ -86,10 +89,10 @@ class MatchServiceTest {
     void registerAsPublisher_ShouldMatchSuccessfully() {
         // given
         when(findPeerService.findWaitingSubscriber(publisherSession)).thenReturn("subscriber-1");
+        when(redisPeerService.isPresent("publisher-1")).thenReturn(true);
+        when(redisPeerService.isPresent("subscriber-1")).thenReturn(true);
         when(sessionService.getSession("subscriber-1")).thenReturn(subscriberSession);
         when(sessionService.getSession("publisher-1")).thenReturn(publisherSession);
-        when(sessionService.isSessionValid(publisherSession)).thenReturn(true);
-        when(sessionService.isSessionValid(subscriberSession)).thenReturn(true);
 
         // when
         matchService.registerAsPublisher(publisherSession);
@@ -105,10 +108,10 @@ class MatchServiceTest {
     void registerAsSubscriber_ShouldMatchSuccessfully() {
         // given
         when(findPeerService.findWaitingPublisher(subscriberSession)).thenReturn("publisher-1");
+        when(redisPeerService.isPresent("publisher-1")).thenReturn(true);
+        when(redisPeerService.isPresent("subscriber-1")).thenReturn(true);
         when(sessionService.getSession("publisher-1")).thenReturn(publisherSession);
         when(sessionService.getSession("subscriber-1")).thenReturn(subscriberSession);
-        when(sessionService.isSessionValid(publisherSession)).thenReturn(true);
-        when(sessionService.isSessionValid(subscriberSession)).thenReturn(true);
 
         // when
         matchService.registerAsSubscriber(subscriberSession);
@@ -125,9 +128,8 @@ class MatchServiceTest {
         // given
         subscriberPeerRelation.setPublisher("publisher-1");
         when(sessionService.remove("subscriber-1")).thenReturn(subscriberPeerRelation);
+        when(redisPeerService.isPresent("publisher-1")).thenReturn(true);
         when(sessionService.getSession("publisher-1")).thenReturn(publisherSession);
-        when(sessionService.getPeerRelation("publisher-1")).thenReturn(publisherPeerRelation);
-        when(sessionService.isSessionValid(publisherSession)).thenReturn(true);
         when(findPeerService.findWaitingSubscriber(publisherSession)).thenReturn(null);
 
         // when
@@ -149,9 +151,8 @@ class MatchServiceTest {
         // given
         publisherPeerRelation.setSubscriber("subscriber-1");
         when(sessionService.remove("publisher-1")).thenReturn(publisherPeerRelation);
+        when(redisPeerService.isPresent("subscriber-1")).thenReturn(true);
         when(sessionService.getSession("subscriber-1")).thenReturn(subscriberSession);
-        when(sessionService.getPeerRelation("subscriber-1")).thenReturn(subscriberPeerRelation);
-        when(sessionService.isSessionValid(subscriberSession)).thenReturn(true);
         when(findPeerService.findWaitingPublisher(subscriberSession)).thenReturn(null);
 
         // when
@@ -176,10 +177,9 @@ class MatchServiceTest {
         lenient().when(newSubscriberSession.getId()).thenReturn("new-subscriber");
 
         when(sessionService.remove("subscriber-1")).thenReturn(subscriberPeerRelation);
+        when(redisPeerService.isPresent("publisher-1")).thenReturn(true);
+        when(redisPeerService.isPresent("new-subscriber")).thenReturn(true);
         when(sessionService.getSession("publisher-1")).thenReturn(publisherSession);
-        when(sessionService.getPeerRelation("publisher-1")).thenReturn(publisherPeerRelation);
-        when(sessionService.isSessionValid(publisherSession)).thenReturn(true);
-        when(sessionService.isSessionValid(newSubscriberSession)).thenReturn(true);
         when(sessionService.getSession("new-subscriber")).thenReturn(newSubscriberSession);
         when(findPeerService.findWaitingSubscriber(publisherSession)).thenReturn("new-subscriber");
 

--- a/src/test/java/com/koa/sws/service/RedisQueueServiceTest.java
+++ b/src/test/java/com/koa/sws/service/RedisQueueServiceTest.java
@@ -1,7 +1,6 @@
 package com.koa.sws.service;
 
 import org.junit.jupiter.api.Test;
-import org.redisson.api.RedissonClient;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
@@ -23,16 +22,21 @@ class RedisQueueServiceTest {
     private RedisQueueService queueService;
 
     @Autowired
-    private RedissonClient redissonClient;
+    private RedisPeerService redisPeerService;
 
     @Test
     void distributedLock_shouldHandleHighConcurrencyPop() throws Exception {
 
-        // 큐 초기화
-        redissonClient.getKeys().delete("sws:publishQueue");
-
         int TOTAL = 1000;
+
+        // 이전 테스트 잔여 데이터 제거 (peer 키 + 큐 항목 동시 정리)
         for (int i = 1; i <= TOTAL; i++) {
+            redisPeerService.remove("USER-" + i, null, null);
+        }
+
+        // peer 등록 후 큐에 추가 (enqueue Lua script가 peer 키 존재를 확인)
+        for (int i = 1; i <= TOTAL; i++) {
+            redisPeerService.register("USER-" + i);
             queueService.addToPublishQueue("USER-" + i);
         }
 

--- a/src/test/java/com/koa/sws/service/SignalMessageRelayServiceTest.java
+++ b/src/test/java/com/koa/sws/service/SignalMessageRelayServiceTest.java
@@ -13,6 +13,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.web.socket.TextMessage;
 import org.springframework.web.socket.WebSocketSession;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
@@ -124,5 +125,17 @@ class SignalMessageRelayServiceTest {
         // then
         verify(objectMapper).writeValueAsString(testMessage);
         verify(session, never()).sendMessage(any());
+    }
+
+    @Test
+    @DisplayName("메시지 전송 실패 - 세션이 닫혀 IllegalStateException 발생 시 예외를 전파하지 않음")
+    void sendMessage_ShouldNotThrowWhenIllegalStateException() throws Exception {
+        // given
+        when(objectMapper.writeValueAsString(testMessage)).thenReturn("{\"type\":\"OFFER\"}");
+        doThrow(new IllegalStateException("TEXT_PARTIAL_WRITING")).when(session).sendMessage(any());
+
+        // when & then
+        assertDoesNotThrow(() -> relayService.sendMessage(session, testMessage));
+        verify(session).sendMessage(any(TextMessage.class));
     }
 }


### PR DESCRIPTION
### 🧩 Summary

Redis 기반 매칭 시스템에서 발생하던 동시성 이슈로 인한 데이터 정합성 문제(를 해결하기 위해 Lua Script를 도입하여 주요 연산을 **atomic하게 처리**하도록 개선했습니다.

또한, WebSocket disconnect 및 메시지 전송 과정에서 발생하는 **race condition 및 예외 상황을 처리**하도록 리팩토링했습니다.

---

### 📋 Related Issue

Closes #18

---

### 💡 Changes

* [Refactor] Redis Lua Script 도입
  * `EXISTS + ZADD` → atomic 처리
  * `remove + dequeue + relation cleanup` → atomic 처리

* [Refactor] 메세지 전송 시 Session close로 인한 에러 처리
  * match 중 session null 체크 추가
  * publisher/subscriber disconnect 시 null-safe 처리
  * `IllegalStateException` (session closed) 예외 처리
  * unregister 과정에서 예외 발생해도 정상 종료 보장

* [Test] 테스트 코드 수정



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of concurrent disconnects with proper null checks to prevent crashes.
  * Enhanced exception handling for closed WebSocket connections.
  * Made peer removal and queue operations atomic using Redis scripts.

* **Tests**
  * Updated test infrastructure for concurrent scenarios.
  * Added coverage for exception handling during message transmission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->